### PR TITLE
Fix wide Emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # master
 - adds highlight keywords feature
 - fix issue related to formatting of strings
+- wide emotes are wide now (still a bit buggy)
 - reduce amount of update notifications (again)
 
 # v0.8.0-beta

--- a/mod/app/src/main/java/bttv/api/GlideChatImageTarget.java
+++ b/mod/app/src/main/java/bttv/api/GlideChatImageTarget.java
@@ -1,0 +1,19 @@
+package bttv.api;
+
+import android.util.Log;
+
+import tv.twitch.android.shared.ui.elements.span.UrlDrawable;
+
+public class GlideChatImageTarget {
+
+    public static boolean getIsBttvEmote(tv.twitch.android.shared.ui.elements.span.GlideChatImageTarget target) {
+        UrlDrawable urlDrawable = target.mUrlDrawable;
+        if (urlDrawable == null) {
+            Log.i("LBTTVDEBUG", "getIsBttvEmote: urlDrawable) is null");
+            return false;
+        }
+        String url = urlDrawable.getUrl();
+        Log.i("LBTTVDEBUG", "getIsBttvEmote: " + url);
+        return url.contains("betterttv.net") || url.contains("7tv.app"); // TODO: find better way of determining this
+    }
+}

--- a/mod/app/src/main/java/bttv/api/GlideChatImageTarget.java
+++ b/mod/app/src/main/java/bttv/api/GlideChatImageTarget.java
@@ -1,6 +1,9 @@
 package bttv.api;
 
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.util.Log;
+import android.widget.TextView;
 
 import tv.twitch.android.shared.ui.elements.span.UrlDrawable;
 
@@ -15,5 +18,30 @@ public class GlideChatImageTarget {
         String url = urlDrawable.getUrl();
         Log.i("LBTTVDEBUG", "getIsBttvEmote: " + url);
         return url.contains("betterttv.net") || url.contains("7tv.app"); // TODO: find better way of determining this
+    }
+
+    public static void setRenderingView(tv.twitch.android.shared.ui.elements.span.GlideChatImageTarget target, TextView view) {
+        target.bttvView = view;
+    }
+
+    public static void invalidateView(tv.twitch.android.shared.ui.elements.span.GlideChatImageTarget target, Drawable drawable) {
+        try {
+            Rect bounds = drawable.getBounds();
+            if (bounds.bottom >= bounds.right) {
+                return;
+            }
+            if (!getIsBttvEmote(target)) {
+                return;
+            }
+            if (target.bttvView == null) {
+                Log.w("LBTTVGlideChatImgTarget", "invalidateView: bttvView is null");
+                return;
+            }
+            target.bttvView.invalidate();
+            target.bttvView.setText(target.bttvView.getText()); // dirty trick to force re-draw
+            target.bttvView = null; // drop ref idk how it could impact GC, and onResourceReady is only called once anyway (I hope)
+        } catch (Throwable e) {
+            Log.e("LBTTVGlideChatImgTarget", "invalidateView: error", e);
+        }
     }
 }

--- a/mod/app/src/main/java/bttv/api/Util.java
+++ b/mod/app/src/main/java/bttv/api/Util.java
@@ -1,0 +1,7 @@
+package bttv.api;
+
+import android.util.Log;
+
+public class Util {
+
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.java
@@ -1,5 +1,8 @@
 package tv.twitch.android.shared.ui.elements.span;
 
+import android.widget.TextView;
+
 public class GlideChatImageTarget {
     public UrlDrawable mUrlDrawable;
+    public TextView bttvView;
 }

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.java
@@ -1,0 +1,5 @@
+package tv.twitch.android.shared.ui.elements.span;
+
+public class GlideChatImageTarget {
+    public UrlDrawable mUrlDrawable;
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/UrlDrawable.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/ui/elements/span/UrlDrawable.java
@@ -1,0 +1,7 @@
+package tv.twitch.android.shared.ui.elements.span;
+
+public final class UrlDrawable {
+    public final String getUrl() {
+        return null;
+    }
+}

--- a/monke.patch
+++ b/monke.patch
@@ -2017,7 +2017,7 @@ index 0ba6c9ef3..d258eaa46 100644
  
      .line 45
 diff --git a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
-index f2c300298..967e304d9 100644
+index f2c300298..ca26f459b 100644
 --- a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
 +++ b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
 @@ -18,7 +18,7 @@
@@ -2038,12 +2038,13 @@ index f2c300298..967e304d9 100644
  
      const/high16 v0, 0x3f800000    # 1.0f
  
-@@ -109,6 +109,14 @@
+@@ -109,6 +109,15 @@
  
      move-result p3
  
 +    # BTTV
 +    #  fix wide emotes
++    invoke-static {p0}, Lbttv/api/GlideChatImageTarget;->getIsBttvEmote(Ltv/twitch/android/shared/ui/elements/span/GlideChatImageTarget;)Z
 +    move-result v3
 +    if-eqz v3, :not_bttv
 +    move p3, v0

--- a/monke.patch
+++ b/monke.patch
@@ -2016,20 +2016,37 @@ index 0ba6c9ef3..d258eaa46 100644
      const/4 v0, 0x1
  
      .line 45
+diff --git a/smali_classes6/tv/twitch/android/shared/ui/elements/GlideHelper.smali b/smali_classes6/tv/twitch/android/shared/ui/elements/GlideHelper.smali
+index 6aeb7db07..3aa8411de 100644
+--- a/smali_classes6/tv/twitch/android/shared/ui/elements/GlideHelper.smali
++++ b/smali_classes6/tv/twitch/android/shared/ui/elements/GlideHelper.smali
+@@ -397,6 +397,10 @@
+ 
+     invoke-direct {v3, p0, v1, v4}, Ltv/twitch/android/shared/ui/elements/span/GlideChatImageTarget;-><init>(Landroid/content/Context;Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;I)V
+ 
++    # BTTV
++    invoke-static {v3, p2}, Lbttv/api/GlideChatImageTarget;->setRenderingView(Ltv/twitch/android/shared/ui/elements/span/GlideChatImageTarget;Landroid/widget/TextView;)V
++    # /BTTV
++
+     .line 70
+     invoke-static {p0}, Lcom/bumptech/glide/Glide;->with(Landroid/content/Context;)Lcom/bumptech/glide/RequestManager;
+ 
 diff --git a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
-index f2c300298..ca26f459b 100644
+index f2c300298..14f2d0831 100644
 --- a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
 +++ b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
-@@ -18,7 +18,7 @@
+@@ -18,8 +18,9 @@
  
  .field private mMaxSideDimenPixel:I
  
 -.field private mUrlDrawable:Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;
 +.field public mUrlDrawable:Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;
  
++.field public bttvView:Landroid/widget/TextView; # BTTV
  
  # direct methods
-@@ -81,7 +81,7 @@
+ .method public constructor <init>(Landroid/content/Context;Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;I)V
+@@ -81,7 +82,7 @@
  .end method
  
  .method private scaleSquared(FFF)Landroid/graphics/Point;
@@ -2038,7 +2055,7 @@ index f2c300298..ca26f459b 100644
  
      const/high16 v0, 0x3f800000    # 1.0f
  
-@@ -109,6 +109,15 @@
+@@ -109,6 +110,15 @@
  
      move-result p3
  
@@ -2054,6 +2071,17 @@ index f2c300298..ca26f459b 100644
      mul-float p1, p1, p3
  
      float-to-int p1, p1
+@@ -230,6 +240,10 @@
+ 
+     invoke-virtual {p2, p1}, Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;->setDrawable(Landroid/graphics/drawable/Drawable;)V
+ 
++    # BTTV
++    invoke-static {p0, p1}, Lbttv/api/GlideChatImageTarget;->invalidateView(Ltv/twitch/android/shared/ui/elements/span/GlideChatImageTarget;Landroid/graphics/drawable/Drawable;)V
++    # /BTTV
++
+     return-void
+ .end method
+ 
 diff --git a/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali b/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali
 index 46cdaa88e..f89941c92 100644
 --- a/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali

--- a/monke.patch
+++ b/monke.patch
@@ -2016,6 +2016,43 @@ index 0ba6c9ef3..d258eaa46 100644
      const/4 v0, 0x1
  
      .line 45
+diff --git a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
+index f2c300298..967e304d9 100644
+--- a/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
++++ b/smali_classes6/tv/twitch/android/shared/ui/elements/span/GlideChatImageTarget.smali
+@@ -18,7 +18,7 @@
+ 
+ .field private mMaxSideDimenPixel:I
+ 
+-.field private mUrlDrawable:Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;
++.field public mUrlDrawable:Ltv/twitch/android/shared/ui/elements/span/UrlDrawable;
+ 
+ 
+ # direct methods
+@@ -81,7 +81,7 @@
+ .end method
+ 
+ .method private scaleSquared(FFF)Landroid/graphics/Point;
+-    .locals 3
++    .locals 4
+ 
+     const/high16 v0, 0x3f800000    # 1.0f
+ 
+@@ -109,6 +109,14 @@
+ 
+     move-result p3
+ 
++    # BTTV
++    #  fix wide emotes
++    move-result v3
++    if-eqz v3, :not_bttv
++    move p3, v0
++    :not_bttv
++    # /BTTV
++
+     mul-float p1, p1, p3
+ 
+     float-to-int p1, p1
 diff --git a/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali b/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali
 index 46cdaa88e..f89941c92 100644
 --- a/smali_classes6/tv/twitch/android/shared/ui/menus/SettingsPreferencesController$SettingsPreference.smali


### PR DESCRIPTION
Fixes #148 

## Changes
- makes wide emotes wide

## TODO:
- [x] only works after tapping once?

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)

