### PR TITLE
Subscribe buttons open Web Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.11.0-beta
 - update to base v11.4.0
+- "Subscribe"-Buttons now open web page
 
 ## v0.10.1-beta
 - minor changes

--- a/mod/app/src/main/java/bttv/SubscribeRedirect.java
+++ b/mod/app/src/main/java/bttv/SubscribeRedirect.java
@@ -1,0 +1,18 @@
+package bttv;
+
+import tv.twitch.android.feature.theatre.common.PlayerCoordinatorPresenter;
+import tv.twitch.android.feature.theatre.metadata.MetadataViewEvent;
+import tv.twitch.android.models.channel.ChannelModel;
+
+public class SubscribeRedirect {
+    public static void openSubscribePage(PlayerCoordinatorPresenter presenter, MetadataViewEvent.SubscribeButtonClicked event) {
+        ChannelModel channel = event.channelModel;
+        String url = getUrl(channel);
+        Util.launchBrowser(presenter.activity, url);
+    }
+
+    private static String getUrl(ChannelModel channel) {
+        String name = channel.component2();
+        return "https://www.twitch.tv/subs/" + name;
+    }
+}

--- a/mod/app/src/main/java/bttv/Util.java
+++ b/mod/app/src/main/java/bttv/Util.java
@@ -1,7 +1,10 @@
 package bttv;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -16,5 +19,11 @@ public class Util {
         b.setCancelable(true);
         b.setPositiveButton(ResUtil.getLocaleString(ctx, "ok_confirmation"), null);
         b.show();
+    }
+
+    public static void launchBrowser(Activity activity, String url) {
+        Intent viewIntent = new Intent(Intent.ACTION_VIEW,
+                Uri.parse(url));
+        activity.startActivity(viewIntent);
     }
 }

--- a/mod/app/src/main/java/bttv/api/SubscribeRedirect.java
+++ b/mod/app/src/main/java/bttv/api/SubscribeRedirect.java
@@ -1,0 +1,19 @@
+package bttv.api;
+
+import android.util.Log;
+
+import tv.twitch.android.feature.theatre.common.PlayerCoordinatorPresenter;
+import tv.twitch.android.feature.theatre.metadata.MetadataViewEvent;
+
+public class SubscribeRedirect {
+    public static final String TAG = "LBTTVSubRedir";
+
+    public static void subscribe(PlayerCoordinatorPresenter presenter, MetadataViewEvent.SubscribeButtonClicked event) {
+        try {
+            Log.d(TAG, "subscribe()");
+            bttv.SubscribeRedirect.openSubscribePage(presenter, event);
+        } catch (Throwable e) {
+            Log.e(TAG, "subscribe: ", e);
+        }
+    }
+}

--- a/mod/app/src/main/java/bttv/api/Util.java
+++ b/mod/app/src/main/java/bttv/api/Util.java
@@ -4,4 +4,8 @@ import android.util.Log;
 
 public class Util {
     final static String TAG = "LBTTVUtil";
+
+    public static void printSubscribe() {
+        Log.i(TAG, "User attempts to subscribe");
+    }
 }

--- a/mod/twitch/src/main/java/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.java
@@ -1,0 +1,5 @@
+package tv.twitch.android.feature.theatre.common;
+
+public abstract class PlayerCoordinatorPresenter {
+    public androidx.fragment.app.FragmentActivity activity;
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent.java
@@ -1,0 +1,7 @@
+package tv.twitch.android.feature.theatre.metadata;
+
+public class MetadataViewEvent {
+    public static final class SubscribeButtonClicked extends MetadataViewEvent {
+        public tv.twitch.android.models.channel.ChannelModel channelModel;
+    }
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/models/channel/ChannelModel.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/models/channel/ChannelModel.java
@@ -8,5 +8,8 @@ public class ChannelModel {
     /** returns id */
     public final int component1() {
         return 0;
-    }
+    } // getId()
+    public final String component2() {
+        return "";
+    } // getName()
 }

--- a/monke.patch
+++ b/monke.patch
@@ -1,5 +1,5 @@
 diff --git a/AndroidManifest.xml b/AndroidManifest.xml
-index ad5f0327a..b25d52669 100644
+index ce6452f57..8ea043a50 100644
 --- a/AndroidManifest.xml
 +++ b/AndroidManifest.xml
 @@ -1,4 +1,15 @@
@@ -197,7 +197,7 @@ index 81978a8c8..708fe13be 100644
 +    <item type="id" name="bttv_sleep_timer_button" />
  </resources>
 diff --git a/res/values/public.xml b/res/values/public.xml
-index 417972714..af221396d 100644
+index 9e1869781..45ff53f95 100644
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
 @@ -12867,4 +12867,55 @@
@@ -559,7 +559,7 @@ index 842c437dc..9b1c22570 100644
      invoke-static {p0}, Lcom/bumptech/glide/Glide;->with(Landroid/content/Context;)Lcom/bumptech/glide/RequestManager;
  
 diff --git a/smali_classes5/tv/twitch/android/app/consumer/TwitchApplication.smali b/smali_classes5/tv/twitch/android/app/consumer/TwitchApplication.smali
-index 8bb13de8b..6a23d4955 100644
+index 515315b5f..bc0efdb09 100644
 --- a/smali_classes5/tv/twitch/android/app/consumer/TwitchApplication.smali
 +++ b/smali_classes5/tv/twitch/android/app/consumer/TwitchApplication.smali
 @@ -180,6 +180,13 @@
@@ -686,6 +686,48 @@ index 1a29310a1..039ac3577 100644
 +    # /BTTV
  
      invoke-static {v2}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+ 
+diff --git a/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter$setMetadata$1.smali b/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter$setMetadata$1.smali
+index ce27dff0b..609e5ca8a 100644
+--- a/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter$setMetadata$1.smali
++++ b/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter$setMetadata$1.smali
+@@ -89,6 +89,11 @@
+ 
+     const/4 v6, 0x0
+ 
++    # BTTV
++    invoke-static {v1, p1}, Lbttv/api/SubscribeRedirect;->subscribe(Ltv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter;Ltv/twitch/android/feature/theatre/metadata/MetadataViewEvent$SubscribeButtonClicked;)V
++    goto :goto_0
++    # /BTTV
++
+     invoke-static/range {v1 .. v6}, Ltv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter;->onSubscribeButtonClicked$feature_theatre_release$default(Ltv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter;Ltv/twitch/android/shared/subscriptions/pager/SubscriptionPageType;Ltv/twitch/android/models/subscriptions/SubscribeButtonTrackingMetadata;Ltv/twitch/android/models/subscriptions/SubscriptionScreen;ILjava/lang/Object;)V
+ 
+     goto :goto_0
+diff --git a/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.smali b/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.smali
+index 8fe9d0fd3..95fff39d7 100644
+--- a/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.smali
++++ b/smali_classes5/tv/twitch/android/feature/theatre/common/PlayerCoordinatorPresenter.smali
+@@ -23,7 +23,7 @@
+ 
+ 
+ # instance fields
+-.field private final activity:Landroidx/fragment/app/FragmentActivity;
++.field public final activity:Landroidx/fragment/app/FragmentActivity;
+ 
+ .field private final adMetadataPresenter:Ltv/twitch/android/feature/theatre/metadata/AdMetadataPresenter;
+ 
+diff --git a/smali_classes5/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent$SubscribeButtonClicked.smali b/smali_classes5/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent$SubscribeButtonClicked.smali
+index 7216cea34..441e60ce1 100644
+--- a/smali_classes5/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent$SubscribeButtonClicked.smali
++++ b/smali_classes5/tv/twitch/android/feature/theatre/metadata/MetadataViewEvent$SubscribeButtonClicked.smali
+@@ -15,7 +15,7 @@
+ 
+ 
+ # instance fields
+-.field private final channelModel:Ltv/twitch/android/models/channel/ChannelModel;
++.field public final channelModel:Ltv/twitch/android/models/channel/ChannelModel;
+ 
+ .field private final pageType:Ltv/twitch/android/shared/subscriptions/pager/SubscriptionPageType;
  
 diff --git a/smali_classes6/tv/twitch/android/models/settings/SettingsDestination.smali b/smali_classes6/tv/twitch/android/models/settings/SettingsDestination.smali
 index f49d74b15..3d314a533 100644


### PR DESCRIPTION
Fixes #226 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
As bttv-android can't communicate with the play store APIs there were issues when a user attempts to subscribe using bttv-android.
This issues is mitigated by redirecting the user to `www.twitch.tv/subs/<channel>`.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
