### PR TITLE
Show deleted messages

### DIFF
--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -58,6 +58,7 @@ public class Res {
         bttv_settings_gif_render_mode_static,
         bttv_settings_gif_render_mode_disabled,
         bttv_settings_open_credits_button_title,
+        bttv_settings_enable_show_deleted_messages,
         bttv_credits_title,
         bttv_credits_intro,
         bttv_credits_bugs,

--- a/mod/app/src/main/java/bttv/api/DeletedMessages.java
+++ b/mod/app/src/main/java/bttv/api/DeletedMessages.java
@@ -1,0 +1,28 @@
+package bttv.api;
+
+import android.graphics.Typeface;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.SpannedString;
+import android.text.style.StyleSpan;
+
+import bttv.ResUtil;
+import bttv.settings.Settings;
+
+
+public class DeletedMessages {
+
+    public static Spanned reSpan(Spanned original) {
+        if (!ResUtil.getBooleanFromSettings(Settings.ShowDeletedMessagesEnabled)) {
+            return null;
+        }
+
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(original);
+        SpannableString postFix = new SpannableString("(removed by mod)");
+        postFix.setSpan(new StyleSpan(Typeface.ITALIC), 0, postFix.length(), 0);
+        spannableStringBuilder.append(postFix);
+
+        return new SpannedString(spannableStringBuilder);
+    }
+}

--- a/mod/app/src/main/java/bttv/settings/Settings.java
+++ b/mod/app/src/main/java/bttv/settings/Settings.java
@@ -56,11 +56,20 @@ public enum Settings {
     ),
     AutoRedeemChannelPointsEnabled(
             new Entry.BoolEntry(
-                "enable_auto_redeem_channel_points",
-                new Entry.BoolValue(true),
-                Res.strings.bttv_settings_enable_auto_redeem_points_primary,
-                null,
-                null
+                    "enable_auto_redeem_channel_points",
+                    new Entry.BoolValue(true),
+                    Res.strings.bttv_settings_enable_auto_redeem_points_primary,
+                    null,
+                    null
+            )
+    ),
+    ShowDeletedMessagesEnabled(
+            new Entry.BoolEntry(
+                    "enable_show_deleted_messages",
+                    new Entry.BoolValue(false),
+                    Res.strings.bttv_settings_enable_show_deleted_messages,
+                    null,
+                    null
             )
     ),
     ShouldShowSleepTimer(

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="bttv_settings_gif_render_mode_static">Static</string>
     <string name="bttv_settings_gif_render_mode_disabled">Disabled</string>
     <string name="bttv_settings_open_credits_button_title">Credits</string>
+    <string name="bttv_settings_enable_show_deleted_messages">Show Deleted Messages</string>
     <string name="bttv_credits_title">Credits</string>
     <string name="bttv_credits_intro">bttv-android was made by <annotation link_to="https://github.com/FoseFx">FoseFx</annotation> with help of these kind folks:</string>
     <string name="bttv_credits_bugs">Bug Reports</string>

--- a/monke.patch
+++ b/monke.patch
@@ -1,5 +1,5 @@
 diff --git a/AndroidManifest.xml b/AndroidManifest.xml
-index 4d89846ac..ec038ceaa 100644
+index ce6452f57..a8bc7afa2 100644
 --- a/AndroidManifest.xml
 +++ b/AndroidManifest.xml
 @@ -1,4 +1,15 @@
@@ -148,7 +148,7 @@ index f2b85353e..92d0ebd81 100644
          <ImageView android:id="@id/write_message_button" android:background="?selectableItemBackgroundBorderless" android:padding="@dimen/default_margin" android:visibility="gone" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginLeft="@dimen/default_margin" android:layout_marginRight="@dimen/default_margin" android:src="@drawable/ic_compose" android:contentDescription="@string/write_message_talkback" app:tint="@color/white" />
          <ImageView android:id="@id/chat_settings_button" android:background="?selectableItemBackgroundBorderless" android:padding="@dimen/default_margin" android:visibility="gone" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginLeft="@dimen/default_margin" android:layout_marginRight="@dimen/default_margin" android:src="@drawable/ic_chat_display_setting" android:contentDescription="@string/chat_settings_talkback" app:tint="@color/white" />
 diff --git a/res/layout/settings_logout_footer.xml b/res/layout/settings_logout_footer.xml
-index e5846b005..c36385e97 100644
+index e5846b005..aae416862 100644
 --- a/res/layout/settings_logout_footer.xml
 +++ b/res/layout/settings_logout_footer.xml
 @@ -2,6 +2,7 @@
@@ -197,10 +197,10 @@ index 631798340..24787f135 100644
 +    <item type="id" name="bttv_sleep_timer_button" />
  </resources>
 diff --git a/res/values/public.xml b/res/values/public.xml
-index 0dc2e1eb0..19f00856c 100644
+index 3569c1ed5..94de38dca 100644
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13041,4 +13041,55 @@
+@@ -13041,4 +13041,56 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -248,11 +248,12 @@ index 0dc2e1eb0..19f00856c 100644
 +    <public type="string" name="bttv_settings_gif_render_mode_static" id="0x7f130db4" />
 +    <public type="string" name="bttv_settings_gif_render_mode_disabled" id="0x7f130db5" />
 +    <public type="string" name="bttv_settings_open_credits_button_title" id="0x7f130db6" />
-+    <public type="string" name="bttv_credits_title" id="0x7f130db7" />
-+    <public type="string" name="bttv_credits_intro" id="0x7f130db8" />
-+    <public type="string" name="bttv_credits_bugs" id="0x7f130db9" />
-+    <public type="string" name="bttv_credits_ideas" id="0x7f130dba" />
-+    <public type="string" name="bttv_credits_translations" id="0x7f130dbb" />
++    <public type="string" name="bttv_settings_enable_show_deleted_messages" id="0x7f130db7" />
++    <public type="string" name="bttv_credits_title" id="0x7f130db8" />
++    <public type="string" name="bttv_credits_intro" id="0x7f130db9" />
++    <public type="string" name="bttv_credits_bugs" id="0x7f130dba" />
++    <public type="string" name="bttv_credits_ideas" id="0x7f130dbb" />
++    <public type="string" name="bttv_credits_translations" id="0x7f130dbc" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f080529" />
 +    <!-- /BTTV -->
  </resources>
@@ -1203,6 +1204,26 @@ index cdd0c056d..69b3c1720 100644
  
  .field private final emoteToken:Ljava/lang/String;
  
+diff --git a/smali_classes6/tv/twitch/android/shared/chat/util/ChatUtil$Companion.smali b/smali_classes6/tv/twitch/android/shared/chat/util/ChatUtil$Companion.smali
+index e62b7104e..1374784e2 100644
+--- a/smali_classes6/tv/twitch/android/shared/chat/util/ChatUtil$Companion.smali
++++ b/smali_classes6/tv/twitch/android/shared/chat/util/ChatUtil$Companion.smali
+@@ -180,6 +180,15 @@
+         }
+     .end annotation
+ 
++    # BTTV
++    invoke-static {p1}, Lbttv/api/DeletedMessages;->reSpan(Landroid/text/Spanned;)Landroid/text/Spanned;
++    move-result-object v0
++    if-eqz v0, :bttv_skip
++    move-object p1, v0
++    goto :cond_1
++    :bttv_skip
++    # /BTTV
++
+     const-string v0, "span"
+ 
+     invoke-static {p1, v0}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullParameter(Ljava/lang/Object;Ljava/lang/String;)V
 diff --git a/smali_classes6/tv/twitch/android/shared/chomments/impl/ChommentsFetcherImpl.smali b/smali_classes6/tv/twitch/android/shared/chomments/impl/ChommentsFetcherImpl.smali
 index 0cad48f74..b14a3bd82 100644
 --- a/smali_classes6/tv/twitch/android/shared/chomments/impl/ChommentsFetcherImpl.smali


### PR DESCRIPTION
Fixes #194<!-- If applicable -->

## Changes
<!-- What does this PR change? -->
Adds a toggle for the user to show messages deleted by a moderator.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
