### PR TITLE
Fix missing emote url replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # master
 - add "show deleted messages" feature
+- fix some bugs related to missing emotes
 
 # v0.13.0-beta
 - rebase to v11.6.0

--- a/mod/app/src/main/java/bttv/emote/EmoteUrlUtil.java
+++ b/mod/app/src/main/java/bttv/emote/EmoteUrlUtil.java
@@ -6,26 +6,7 @@ import android.util.Log;
 import tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil;
 
 public class EmoteUrlUtil {
-    private static final String TAG = "LBTTVEMoteurlUtil";
-
-    public static AnimatedEmotesUrlUtil.EmoteUrlDetails generateEmoteUrl(AnimatedEmotesUrlUtil util, Context context, String id, float f, AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting emoteUrlAnimationSetting) {
-        String realId = extractBTTVId(id);
-        if (realId != null) {
-            return wrapInDetails(realIdToUrl(realId));
-        } else if (util != null) {
-            return util.generateEmoteUrl(context, id, f, emoteUrlAnimationSetting);
-        } else {
-            return wrapInDetails(tv.twitch.android.util.EmoteUrlUtil.generateEmoteUrl(id, f));
-        }
-    }
-
-    public static String getEmoteUrl(AnimatedEmotesUrlUtil util, Context c, String id) {
-        if (id.startsWith("BTTV-")) {
-            return EmoteUrlUtil.generateEmoteUrl(util, c, id, 1.0f, AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting.DEFAULT).getEmoteUrl();
-        } else {
-            return util.getEmoteUrl(c, id);
-        }
-    }
+    private static final String TAG = "LBTTVEmoteurlUtil";
 
     public static String getEmoteUrl(String id) {
         String realId = extractBTTVId(id);
@@ -51,7 +32,4 @@ public class EmoteUrlUtil {
         return emote.url;
     }
 
-    private static AnimatedEmotesUrlUtil.EmoteUrlDetails wrapInDetails(String s) {
-        return new AnimatedEmotesUrlUtil.EmoteUrlDetails(s, AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting.DEFAULT);
-    }
 }

--- a/monke.patch
+++ b/monke.patch
@@ -1103,7 +1103,7 @@ index 2f4cf70db..74cb66121 100644
      instance-of v1, p1, Ltv/twitch/android/shared/chat/model/EmoteCardModel$ChannelPointsEmoteCardModel;
  
 diff --git a/smali_classes6/tv/twitch/android/shared/chat/messagefactory/ChatMessageFactory.smali b/smali_classes6/tv/twitch/android/shared/chat/messagefactory/ChatMessageFactory.smali
-index ba3b7cbe1..fa79bdac9 100644
+index ba3b7cbe1..269d89935 100644
 --- a/smali_classes6/tv/twitch/android/shared/chat/messagefactory/ChatMessageFactory.smali
 +++ b/smali_classes6/tv/twitch/android/shared/chat/messagefactory/ChatMessageFactory.smali
 @@ -623,6 +623,12 @@
@@ -1119,24 +1119,7 @@ index ba3b7cbe1..fa79bdac9 100644
      if-eqz p12, :cond_4
  
      .line 678
-@@ -1318,7 +1324,15 @@
- 
-     sget-object v6, Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;->STATIC:Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;
- 
--    invoke-virtual {v0, v3, v4, v5, v6}, Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil;->generateEmoteUrl(Landroid/content/Context;Ljava/lang/String;FLtv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;)Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlDetails;
-+    # BTTV
-+    #     expects:
-+    #     - v0: tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil
-+    #     - v3: android.content.Context
-+    #     - v4: java.lang.String
-+    #     - v5: F
-+    #     - v6: AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting
-+    invoke-static {v0, v3, v4, v5, v6}, Lbttv/emote/EmoteUrlUtil;->generateEmoteUrl(Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil;Landroid/content/Context;Ljava/lang/String;FLtv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;)Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlDetails;
-+    # /BTTV
- 
-     move-result-object v0
- 
-@@ -2736,6 +2750,13 @@
+@@ -2736,6 +2742,13 @@
  
      move-object/from16 v0, p1
  
@@ -1150,7 +1133,7 @@ index ba3b7cbe1..fa79bdac9 100644
      const-string v1, "chatMessageInfo"
  
      invoke-static {v0, v1}, Lkotlin/jvm/internal/Intrinsics;->checkNotNullParameter(Ljava/lang/Object;Ljava/lang/String;)V
-@@ -4072,6 +4093,13 @@
+@@ -4072,6 +4085,13 @@
      .line 305
      iget-object v6, v0, Ltv/twitch/chat/ChatSubscriptionNotice;->userMessage:Ltv/twitch/chat/ChatMessageInfo;
  
@@ -1275,24 +1258,35 @@ index dfcd86f6c..a0a8e4ff6 100644
      .line 237
      invoke-virtual {p2}, Ltv/twitch/android/util/Optional;->isPresent()Z
  
-diff --git a/smali_classes6/tv/twitch/android/shared/emotes/emotepicker/adapter/EmoteAdapterItem.smali b/smali_classes6/tv/twitch/android/shared/emotes/emotepicker/adapter/EmoteAdapterItem.smali
-index ee78921c6..83cd44107 100644
---- a/smali_classes6/tv/twitch/android/shared/emotes/emotepicker/adapter/EmoteAdapterItem.smali
-+++ b/smali_classes6/tv/twitch/android/shared/emotes/emotepicker/adapter/EmoteAdapterItem.smali
-@@ -369,7 +369,13 @@
+diff --git a/smali_classes6/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.smali b/smali_classes6/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.smali
+index c20456261..9776d5d9d 100644
+--- a/smali_classes6/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.smali
++++ b/smali_classes6/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.smali
+@@ -126,6 +126,16 @@
+     :goto_2
+     new-instance p4, Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlDetails;
  
-     move-result-object v3
- 
--    invoke-virtual {v1, v2, v3}, Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil;->getEmoteUrl(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/String;
 +    # BTTV
-+    #     expects:
-+    #     - v1: tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil
-+    #     - v2: android.content.Context
-+    #     - v3: java.jang.String
-+    invoke-static {v1, v2, v3}, Lbttv/emote/EmoteUrlUtil;->getEmoteUrl(Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil;Landroid/content/Context;Ljava/lang/String;)Ljava/lang/String;
++    #  use our url if bttv emote
++    invoke-static {p2}, Lbttv/emote/EmoteUrlUtil;->getEmoteUrl(Ljava/lang/String;)Ljava/lang/String;
++    move-result-object v1
++    if-eqz v1, :after_bttv
++    move-object p1, v1
++    goto :after_url_built
++    :after_bttv
 +    # /BTTV
++
+     .line 115
+     new-instance v1, Ljava/lang/StringBuilder;
  
-     move-result-object v1
+@@ -159,6 +169,8 @@
+ 
+     move-result-object p1
+ 
++    :after_url_built
++
+     .line 114
+     invoke-direct {p4, p1, p3}, Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlDetails;-><init>(Ljava/lang/String;Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;)V
  
 diff --git a/smali_classes6/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali b/smali_classes6/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali
 index 3d2ad62a6..fa1538124 100644


### PR DESCRIPTION
Related to #269 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
It seems like v11.6.0 added some codepaths that were not hooked. I move the replacements "a layer deeper", which reduces code and should cover all code paths.


## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
