### PR TITLE
Properly generate static emotes + add render forever mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # master
 - rebase to v11.7.0
 - add split chat feature
+- Emotes now behave like animated sub emotes, you disable this in the settings
 
 # v0.13.1-beta
 - add "show deleted messages" feature

--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -55,6 +55,8 @@ public class Res {
         bttv_settings_highlights_dia_title,
         bttv_settings_gif_render_mode_title,
         bttv_settings_gif_render_mode_animate,
+        bttv_settings_gif_render_mode_animate_forever,
+        bttv_settings_gif_render_mode_descr,
         bttv_settings_gif_render_mode_static,
         bttv_settings_gif_render_mode_disabled,
         bttv_settings_open_credits_button_title,

--- a/mod/app/src/main/java/bttv/emote/EmoteUrlUtil.java
+++ b/mod/app/src/main/java/bttv/emote/EmoteUrlUtil.java
@@ -1,12 +1,22 @@
 package bttv.emote;
 
-import android.content.Context;
 import android.util.Log;
 
 import tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil;
 
 public class EmoteUrlUtil {
     private static final String TAG = "LBTTVEmoteurlUtil";
+
+    public static String getEmoteUrl(String id, AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting setting) {
+        String url = getEmoteUrl(id);
+        if (url == null) {
+            return null;
+        }
+        if (setting == AnimatedEmotesUrlUtil.EmoteUrlAnimationSetting.STATIC) {
+            return url + "?static=true";
+        }
+        return url;
+    }
 
     public static String getEmoteUrl(String id) {
         String realId = extractBTTVId(id);

--- a/mod/app/src/main/java/bttv/emote/Glide.java
+++ b/mod/app/src/main/java/bttv/emote/Glide.java
@@ -36,7 +36,8 @@ public class Glide {
         if (urlDrawable.getUrl().endsWith("?static=true") && !ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate_forever)) {
             return false;
         }
-        return ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate);
+        return ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate)
+                || ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate_forever);
     }
 
     public static void setRenderingView(GlideChatImageTarget target, TextView view) {

--- a/mod/app/src/main/java/bttv/emote/Glide.java
+++ b/mod/app/src/main/java/bttv/emote/Glide.java
@@ -33,6 +33,9 @@ public class Glide {
         if (!getIsBttvEmote(urlDrawable)) {
             return true;
         }
+        if (urlDrawable.getUrl().endsWith("?static=true") && !ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate_forever)) {
+            return false;
+        }
         return ResUtil.selectedDropdownFromSettingsIs(Settings.GifRenderMode, Res.strings.bttv_settings_gif_render_mode_animate);
     }
 

--- a/mod/app/src/main/java/bttv/settings/Settings.java
+++ b/mod/app/src/main/java/bttv/settings/Settings.java
@@ -25,6 +25,7 @@ public enum Settings {
                     "bttv_gif_render_mode",
                     new Entry.DropDownValue(
                             new ArrayList<>(Arrays.asList(
+                                    Res.strings.bttv_settings_gif_render_mode_animate_forever,
                                     Res.strings.bttv_settings_gif_render_mode_animate,
                                     Res.strings.bttv_settings_gif_render_mode_static,
                                     Res.strings.bttv_settings_gif_render_mode_disabled
@@ -32,7 +33,7 @@ public enum Settings {
                             Res.strings.bttv_settings_gif_render_mode_animate
                     ),
                     Res.strings.bttv_settings_gif_render_mode_title,
-                    null,
+                    Res.strings.bttv_settings_gif_render_mode_descr,
                     null
             )
     ),

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -43,4 +43,6 @@
     <string name="bttv_copied_to_clipboard">Username copied to clipboard</string>
     <string name="bttv_settings_enable_split_chat">Split Chat</string>
     <string name="bttv_settings_enable_split_chat_descr">Tint the background of every second chat message</string>
+    <string name="bttv_settings_gif_render_mode_animate_forever">Animate forever</string>
+    <string name="bttv_settings_gif_render_mode_descr">Note: "Animate forever" might drain your battery really fast</string>
 </resources>

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil.java
@@ -13,7 +13,8 @@ public class AnimatedEmotesUrlUtil {
     }
 
     public enum EmoteUrlAnimationSetting {
-        DEFAULT("default");
+        DEFAULT("default"),
+        STATIC("static");
         EmoteUrlAnimationSetting(String s){};
     }
 

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13126,4 +13126,58 @@
+@@ -13126,4 +13126,60 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -57,6 +57,8 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_credits_translations" id="0x7f130dd7" />
 +    <public type="string" name="bttv_settings_enable_split_chat" id="0x7f130dd8" />
 +    <public type="string" name="bttv_settings_enable_split_chat_descr" id="0x7f130dd9" />
++    <public type="string" name="bttv_settings_gif_render_mode_animate_forever" id="0x7f130dda" />
++    <public type="string" name="bttv_settings_gif_render_mode_descr" id="0x7f130ddb" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08052c" />
 +    <!-- /BTTV -->
  </resources>

--- a/patches/tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil.smali.patch
+++ b/patches/tv.twitch.android.shared.emotes.utils.AnimatedEmotesUrlUtil.smali.patch
@@ -7,7 +7,7 @@ diff --git a/smali_classes6/tv/twitch/android/shared/emotes/utils/AnimatedEmotes
  
 +    # BTTV
 +    #  use our url if bttv emote
-+    invoke-static {p2}, Lbttv/emote/EmoteUrlUtil;->getEmoteUrl(Ljava/lang/String;)Ljava/lang/String;
++    invoke-static {p2, p3}, Lbttv/emote/EmoteUrlUtil;->getEmoteUrl(Ljava/lang/String;Ltv/twitch/android/shared/emotes/utils/AnimatedEmotesUrlUtil$EmoteUrlAnimationSetting;)Ljava/lang/String;
 +    move-result-object v1
 +    if-eqz v1, :after_bttv
 +    move-object p1, v1


### PR DESCRIPTION
Fixes #274 <!-- If applicable -->
Maybe also #152

## Changes
<!-- What does this PR change? -->
Previous versions did not generate static version of the emotes properly, so they could not be switched to like animated sub emotes for example. This is now fixed.

For those that desire the old render mode (just animate forever at the cost of CPU & battery) a new option was added to the drop down.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
