### PR TITLE
Add owner and type of Emote to EmoteCard

### DIFF
--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -46,6 +46,8 @@ public class Res {
         bttv_settings_enable_auto_redeem_points_primary,
         bttv_settings_show_sleep_timer_primary,
         bttv_emote_added_by_bttv,
+        bttv_emote_added_by_bttv_ffz,
+        bttv_emote_added_by_bttv_stv,
         bttv_updater_downloading,
         bttv_updater_downloading_version,
         bttv_updater_notice,

--- a/mod/app/src/main/java/bttv/api/Strings.java
+++ b/mod/app/src/main/java/bttv/api/Strings.java
@@ -1,14 +1,8 @@
 package bttv.api;
 
-import bttv.Res;
 import bttv.ResUtil;
-import tv.twitch.android.shared.chat.emotecard.EmoteCardViewDelegate;
 
 public class Strings {
-    public static String getEmoteAddedByBttvString(EmoteCardViewDelegate delegate) {
-        return ResUtil.getLocaleString(delegate.getContext(), Res.strings.bttv_emote_added_by_bttv);
-    }
-
     public static int getStringId(String strName) {
         return ResUtil.getStringId(strName);
     }

--- a/mod/app/src/main/java/bttv/emote/Emote.java
+++ b/mod/app/src/main/java/bttv/emote/Emote.java
@@ -17,13 +17,15 @@ public class Emote {
     public String code;
     public String url;
     public String imageType;
+    public String owner;
 
-    public Emote(String id, Emotes.Source source, String code, String url, String imageType) {
+    public Emote(String id, Emotes.Source source, String code, String url, String imageType, String owner) {
         this.id = id;
         this.source = source;
         this.code = code;
         this.url = url;
         this.imageType = imageType;
+        this.owner = owner;
     }
 
     public static Emote fromJson(JSONObject jsonObject, Emotes.Source source) throws JSONException {
@@ -31,18 +33,22 @@ public class Emote {
         String code;
         String url;
         String imageType = "";
+        String owner = null;
 
         switch (source) {
             case BTTV:
                 code = jsonObject.getString("code");
                 url = "https://cdn.betterttv.net/emote/" + id + "/1x";
                 imageType = jsonObject.getString("imageType");
+                owner = null; // we don't get the owner :/
                 break;
             case FFZ:
                 code = jsonObject.getString("code");
                 JSONObject images = jsonObject.getJSONObject("images");
                 url = images.getString("1x");
-                imageType = "png";
+                imageType = jsonObject.getString("imageType");
+                if (jsonObject.has("user"))
+                    owner = jsonObject.getJSONObject("user").getString("displayName");
                 break;
             case STV:
                 code = jsonObject.getString("name");
@@ -55,15 +61,17 @@ public class Emote {
                 } else {
                     imageType = "png";
                 }
+                owner = jsonObject.getJSONObject("owner").getString("display_name");
                 break;
             default:
                 Log.w("LBTTVEmoteFromJson", "source unknown: " + source);
                 url = "";
                 code = "";
                 imageType = "";
+                owner = null;
         }
 
-        return new Emote(id, source, code, url, imageType);
+        return new Emote(id, source, code, url, imageType, owner);
     }
 
     public static List<Emote> fromJSONArray(String json, Emotes.Source source) throws JSONException {

--- a/mod/app/src/main/java/bttv/emote/EmoteCardUtil.java
+++ b/mod/app/src/main/java/bttv/emote/EmoteCardUtil.java
@@ -1,5 +1,10 @@
 package bttv.emote;
 
+import android.util.Log;
+
+import bttv.Data;
+import bttv.Res;
+import bttv.ResUtil;
 import io.reactivex.Single;
 import tv.twitch.android.shared.chat.model.EmoteCardModel;
 import tv.twitch.android.shared.chat.parser.EmoteCardModelParser;
@@ -9,11 +14,51 @@ import tv.twitch.android.models.emotes.EmoteModelAssetType;
 public class EmoteCardUtil {
 
     public static class BTTVEmoteCardModel extends EmoteCardModel.GlobalEmoteCardModel {
+        String emoteId;
         public BTTVEmoteCardModel(String emoteId, String token) {
             super(emoteId, token, EmoteModelAssetType.ANIMATED);
+            this.emoteId = emoteId;
+        }
+
+        // called in Ltv/twitch/android/shared/chat/emotecard/EmoteCardViewDelegate.renderGenericEmoteCard()
+        public String getEmoteDesc() {
+            try {
+                String fallback = ResUtil.getLocaleString(Data.ctx, Res.strings.bttv_emote_added_by_bttv);
+                String id = EmoteUrlUtil.extractBTTVId(this.emoteId);
+                Emote emote = Emotes.getEmoteById(id);
+
+                if (emote == null) {
+                    Log.w("LBTTVEmoteCardUtil", "could not find emote for BTTVEmoteCardModel, emoteId: " + this.emoteId);
+                    return fallback;
+                }
+
+                String owner = emote.owner;
+
+                if (owner == null)
+                    return fallback; // can happen (and will happen for BTTV emotes)
+
+                Res.strings templateStrings;
+                switch (emote.source) {
+                    case STV:
+                        templateStrings = Res.strings.bttv_emote_added_by_bttv_stv;
+                        break;
+                    case FFZ:
+                        templateStrings = Res.strings.bttv_emote_added_by_bttv_ffz;
+                        break;
+                    default:
+                        return fallback;
+                }
+
+                String template = ResUtil.getLocaleString(Data.ctx, templateStrings);
+                return String.format(template, owner);
+            } catch (Throwable t) {
+                Log.e("LBTTVEmoteCardUtil", "getEmoteDesc(): ", t);
+                return "An error has occurred";
+            }
         }
     }
 
+    // called in Ltv/twitch/android/shared/chat/api/EmoteCardApi.getEmoteCardModelResponse()
     public static Single<EmoteCardModelParser.EmoteCardModelResponse> getEmoteResponseOrNull(String emoteId) {
         if (!emoteId.startsWith("BTTV-")) {
             return null;

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -22,6 +22,10 @@
     <string name="bttv_settings_enable_auto_redeem_points_primary">Auto-Redeem Channel Points</string>
     <string name="bttv_settings_show_sleep_timer_primary">Show Sleep Timer</string>
     <string name="bttv_emote_added_by_bttv">Emote added by bttv-android</string>
+    <!-- e.g.: FrankerFaceZ Emote added by FoseFx -->
+    <string name="bttv_emote_added_by_bttv_ffz">FrankerFaceZ Emote added by %s</string>
+    <!-- e.g.: 7TV Emote added by FoseFx -->
+    <string name="bttv_emote_added_by_bttv_stv">7TV Emote added by %s</string>
     <string name="bttv_updater_downloading">Downloading</string>
     <string name="bttv_updater_downloading_version">Downloading %s</string>
     <string name="bttv_updater_notice">If this is the first time you use the updater, allow installations from this source when the wizard asks you for it.</string>

--- a/mod/app/src/test/java/bttv/mod/RetokenizeTest.java
+++ b/mod/app/src/test/java/bttv/mod/RetokenizeTest.java
@@ -209,8 +209,8 @@ public class RetokenizeTest {
         Data.setCurrentBroadcasterId(10);
         Emotes.addChannelFFZ(10,
                 Arrays.asList(
-                    new Emote("5ea831f074046462f768097a", Emotes.Source.FFZ, "KEKW", null, "png"),
-                    new Emote("5ff827395ef7d10c7912c106", Emotes.Source.FFZ,"Pog", null, "png"))
+                    new Emote("5ea831f074046462f768097a", Emotes.Source.FFZ, "KEKW", null, "png", "FoseFx"),
+                    new Emote("5ff827395ef7d10c7912c106", Emotes.Source.FFZ,"Pog", null, "png", "FoseFx"))
         );
 
         // test

--- a/mod/app/src/test/java/bttv/mod/TokenizerTest.java
+++ b/mod/app/src/test/java/bttv/mod/TokenizerTest.java
@@ -143,8 +143,8 @@ public class TokenizerTest {
         Data.setCurrentBroadcasterId(10);
         Emotes.addChannelFFZ(10,
                 Arrays.asList(
-                    new Emote("5ea831f074046462f768097a", Emotes.Source.FFZ, "KEKW", null, "png"),
-                    new Emote("5ff827395ef7d10c7912c106", Emotes.Source.FFZ,"Pog", null, "png"))
+                    new Emote("5ea831f074046462f768097a", Emotes.Source.FFZ, "KEKW", null, "png", "FoseFx"),
+                    new Emote("5ff827395ef7d10c7912c106", Emotes.Source.FFZ,"Pog", null, "png", "FoseFx"))
         );
 
         // test

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13126,4 +13126,60 @@
+@@ -13126,4 +13126,62 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -37,28 +37,30 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_sleep_timer_cancel_dialog_title" id="0x7f130dc3" />
 +    <public type="string" name="bttv_sleep_timer_cancel_dialog_message" id="0x7f130dc4" />
 +    <public type="string" name="bttv_emote_added_by_bttv" id="0x7f130dc5" />
-+    <public type="string" name="bttv_updater_downloading" id="0x7f130dc6" />
-+    <public type="string" name="bttv_updater_downloading_version" id="0x7f130dc7" />
-+    <public type="string" name="bttv_updater_notice" id="0x7f130dc8" />
-+    <public type="string" name="bttv_settings_open_highlights_dia_primary" id="0x7f130dc9" />
-+    <public type="string" name="bttv_settings_open_highlights_dia_secondary" id="0x7f130dca" />
-+    <public type="string" name="bttv_settings_highlights_dia_input_hint" id="0x7f130dcb" />
-+    <public type="string" name="bttv_settings_highlights_dia_title" id="0x7f130dcc" />
-+    <public type="string" name="bttv_settings_gif_render_mode_title" id="0x7f130dcd" />
-+    <public type="string" name="bttv_settings_gif_render_mode_animate" id="0x7f130dce" />
-+    <public type="string" name="bttv_settings_gif_render_mode_static" id="0x7f130dcf" />
-+    <public type="string" name="bttv_settings_gif_render_mode_disabled" id="0x7f130dd0" />
-+    <public type="string" name="bttv_settings_open_credits_button_title" id="0x7f130dd1" />
-+    <public type="string" name="bttv_settings_enable_show_deleted_messages" id="0x7f130dd2" />
-+    <public type="string" name="bttv_credits_title" id="0x7f130dd3" />
-+    <public type="string" name="bttv_credits_intro" id="0x7f130dd4" />
-+    <public type="string" name="bttv_credits_bugs" id="0x7f130dd5" />
-+    <public type="string" name="bttv_credits_ideas" id="0x7f130dd6" />
-+    <public type="string" name="bttv_credits_translations" id="0x7f130dd7" />
-+    <public type="string" name="bttv_settings_enable_split_chat" id="0x7f130dd8" />
-+    <public type="string" name="bttv_settings_enable_split_chat_descr" id="0x7f130dd9" />
-+    <public type="string" name="bttv_settings_gif_render_mode_animate_forever" id="0x7f130dda" />
-+    <public type="string" name="bttv_settings_gif_render_mode_descr" id="0x7f130ddb" />
++    <public type="string" name="bttv_emote_added_by_bttv_ffz" id="0x7f130dc6" />
++    <public type="string" name="bttv_emote_added_by_bttv_stv" id="0x7f130dc7" />
++    <public type="string" name="bttv_updater_downloading" id="0x7f130dc8" />
++    <public type="string" name="bttv_updater_downloading_version" id="0x7f130dc9" />
++    <public type="string" name="bttv_updater_notice" id="0x7f130dca" />
++    <public type="string" name="bttv_settings_open_highlights_dia_primary" id="0x7f130dcb" />
++    <public type="string" name="bttv_settings_open_highlights_dia_secondary" id="0x7f130dcc" />
++    <public type="string" name="bttv_settings_highlights_dia_input_hint" id="0x7f130dcd" />
++    <public type="string" name="bttv_settings_highlights_dia_title" id="0x7f130dce" />
++    <public type="string" name="bttv_settings_gif_render_mode_title" id="0x7f130dcf" />
++    <public type="string" name="bttv_settings_gif_render_mode_animate" id="0x7f130dd0" />
++    <public type="string" name="bttv_settings_gif_render_mode_static" id="0x7f130dd1" />
++    <public type="string" name="bttv_settings_gif_render_mode_disabled" id="0x7f130dd2" />
++    <public type="string" name="bttv_settings_gif_render_mode_animate_forever" id="0x7f130dd3" />
++    <public type="string" name="bttv_settings_gif_render_mode_descr" id="0x7f130dd4" />
++    <public type="string" name="bttv_settings_open_credits_button_title" id="0x7f130dd5" />
++    <public type="string" name="bttv_settings_enable_show_deleted_messages" id="0x7f130dd6" />
++    <public type="string" name="bttv_settings_enable_split_chat" id="0x7f130dd7" />
++    <public type="string" name="bttv_settings_enable_split_chat_descr" id="0x7f130dd8" />
++    <public type="string" name="bttv_credits_title" id="0x7f130dd9" />
++    <public type="string" name="bttv_credits_intro" id="0x7f130dda" />
++    <public type="string" name="bttv_credits_bugs" id="0x7f130ddb" />
++    <public type="string" name="bttv_credits_ideas" id="0x7f130ddc" />
++    <public type="string" name="bttv_credits_translations" id="0x7f130ddd" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08052c" />
 +    <!-- /BTTV -->
  </resources>

--- a/patches/tv.twitch.android.shared.chat.emotecard.EmoteCardViewDelegate.smali.patch
+++ b/patches/tv.twitch.android.shared.chat.emotecard.EmoteCardViewDelegate.smali.patch
@@ -10,7 +10,7 @@ diff --git a/smali_classes6/tv/twitch/android/shared/chat/emotecard/EmoteCardVie
 +
 +    if-eqz v1, :after_bttv
 +
-+    invoke-static {p0}, Lbttv/api/Strings;->getEmoteAddedByBttvString(Ltv/twitch/android/shared/chat/emotecard/EmoteCardViewDelegate;)Ljava/lang/String;
++    invoke-virtual {p1}, Lbttv/emote/EmoteCardUtil$BTTVEmoteCardModel;->getEmoteDesc()Ljava/lang/String;
 +    move-result-object p1
 +
 +    goto :goto_0


### PR DESCRIPTION
Fixes #25 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
- Add owner and type of Emote to EmoteCard for non-bttv emotes

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
