### PR TITLE
Highlight users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # master
 - improve the highlight keyword dialog
 - highlight keywords in VODs
+- you can now highlight users like this: &lt;fosefx&gt;
 
 # v0.14.1-beta
 - fix webp animations (again)

--- a/mod/app/src/main/java/bttv/ChommentModelDelegateWrapper.java
+++ b/mod/app/src/main/java/bttv/ChommentModelDelegateWrapper.java
@@ -1,9 +1,12 @@
 package bttv;
 
+import android.util.Log;
+
 import androidx.core.util.Pair;
 
 import java.util.List;
 
+import bttv.highlight.Highlight;
 import kotlin.jvm.internal.BTTVDefaultConstructorMarker;
 import tv.twitch.android.models.chat.MessageToken;
 import tv.twitch.android.models.chomments.ChommentModel;
@@ -32,9 +35,21 @@ public class ChommentModelDelegateWrapper extends ChommentModelDelegate {
     }
 
     public boolean BTTVshouldHighlight() {
+        if (this.BTTVshouldHighlightChannel()) {
+            Log.i("LBTTVHighl", "BTTVshouldHighlightChannel() returned true");
+            return true;
+        }
         if (this.BTTVshouldHighlightB == null) {
             this.getTokens();
         }
         return this.BTTVshouldHighlightB;
+    }
+
+    private boolean BTTVshouldHighlightChannel() {
+        if (this.getDisplayName() != null && Highlight.shouldHighlightChannel(this.getDisplayName())) {
+            return true;
+        } else {
+            return this.getUserName() != null && Highlight.shouldHighlightChannel(this.getUserName());
+        }
     }
 }

--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -75,5 +75,6 @@ public class Res {
         bttv_settings_enable_split_chat,
         bttv_settings_enable_split_chat_descr,
         bttv_highlight_dia_list_empty,
+        bttv_highlight_user_notice,
     }
 }

--- a/mod/app/src/main/java/bttv/highlight/Highlight.java
+++ b/mod/app/src/main/java/bttv/highlight/Highlight.java
@@ -88,7 +88,14 @@ public class Highlight {
 
     public static boolean shouldHighlight(String word) {
         loadSet();
+        if (word.startsWith("<") || word.endsWith(">"))
+            return false;
         return highlightSet.contains(word.toLowerCase());
+    }
+
+    public static boolean shouldHighlightChannel(String name) {
+        loadSet();
+        return highlightSet.contains("<" + name.toLowerCase() + ">");
     }
 
     public static boolean isEmpty() {

--- a/mod/app/src/main/java/bttv/highlight/Highlight.java
+++ b/mod/app/src/main/java/bttv/highlight/Highlight.java
@@ -55,7 +55,10 @@ public class Highlight {
             return num;
         }
 
-        if (delegate.mChatMessage.messageType.equals("bttv-highlighted-message")) {
+        if (delegate.mChatMessage.messageType.equals("bttv-highlighted-message")
+                || (delegate.getUserName() != null && Highlight.shouldHighlightChannel(delegate.getUserName()))
+                || (delegate.getDisplayName() != null && Highlight.shouldHighlightChannel(delegate.getDisplayName()))
+        ) {
             num = ResUtil.getResourceId(Res.colors.bttv_sonic);
         }
         return num;

--- a/mod/app/src/main/res/layout/bttv_highlight_dialog.xml
+++ b/mod/app/src/main/res/layout/bttv_highlight_dialog.xml
@@ -44,6 +44,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         </ListView>
+
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/bttv_highlight_user_notice"
+            android:textSize="13sp"
+            android:textAlignment="center" />
+
     </LinearLayout>
 
     <LinearLayout

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
     <string name="bttv_settings_gif_render_mode_animate_forever">Animate forever</string>
     <string name="bttv_settings_gif_render_mode_descr">Note: "Animate forever" might drain your battery really fast</string>
     <string name="bttv_highlight_dia_list_empty">There\'s nothing here\n¯\\_(ツ)_/¯</string>
+    <string name="bttv_highlight_user_notice"><![CDATA[You can highlight a user like <this>. e.g.: <fosefx>]]></string>
 </resources>

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13126,4 +13126,66 @@
+@@ -13126,4 +13126,67 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -65,6 +65,7 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_credits_ideas" id="0x7f130ddc" />
 +    <public type="string" name="bttv_credits_translations" id="0x7f130ddd" />
 +    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130dde" />
++    <public type="string" name="bttv_highlight_user_notice" id="0x7f130ddf" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08052c" />
 +    <!-- /BTTV -->
  </resources>


### PR DESCRIPTION
Fixes #180 <!-- If applicable -->

## Changes
You can now highlight users like this: `<fosefx>`

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
