### PR TITLE
Stabilize Split Chat

### DIFF
--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -99,14 +99,12 @@ public class SplitChat {
 
     /** called after Twitch removes the first N Messages from the buffer */
     public static void removedNMessages(int n) {
-        Log.d(TAG, "removedNMessages(" + n + "): prev=" + totalRemovedMessages + ", after=" + (totalRemovedMessages + n));
         totalRemovedMessages += n;
     }
 
     private static boolean shouldTintBG(int positionInAdapter) {
         // see comment on totalRemovedMessages to see why we do this
         int totalPosition = positionInAdapter + totalRemovedMessages;
-        Log.d(TAG, "shouldTintBG() positionInAdapter: " + positionInAdapter + " totalRemovedMessages: " + totalRemovedMessages + " totalPosition:" + totalPosition);
         return totalPosition % 2 == 1;
     }
 

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -17,6 +17,28 @@ import tv.twitch.android.shared.chat.messagefactory.adapteritem.UserNoticeRecycl
 public class SplitChat {
     private final static String TAG = "LBTTVSplitChat";
 
+    /**
+     * The Buffer backing the Chat has a fixed Capacity and is cleared when it overflows;
+     * Old messages get removed. This means we can't rely on the position parameter in
+     * onBindViewHolder() to determine the background color:
+     *
+     * Example:
+     *   Capacity is 3.
+     *   1 new message arrive:
+     * - Old Message | bound with position 0 (even) (will be removed)
+     * - Old Message | bound with position 1 (odd)
+     * - Old Message | bound with position 2 (even)
+     * - New Message | binding with position 2 (even)
+     *
+     * So now two even elements are next to each other.
+     *
+     * To counter this we continue to count the "absolute" position by keeping track of the
+     * total removed messages.
+     *
+     * totalPosition = positionInAdapter + totalRemovedMessages
+     */
+    private static int totalRemovedMessages = 0;
+
     public static void setBackgroundColor(int position, RecyclerView.ViewHolder viewHolder) {
         if (!ResUtil.getBooleanFromSettings(Settings.SplitChatEnabled)) {
             return;
@@ -49,7 +71,7 @@ public class SplitChat {
                 ? ResUtil.getColorValue("material_grey_900")
                 : ResUtil.getColorValue("material_grey_300");
 
-        boolean doChange = position % 2 == 1;
+        boolean doChange = shouldTintBG(position);
 
         // for some reason we can't set the background for the whole view for Chomments (VODs)
         // so we just highlight the TextView (first child)
@@ -73,6 +95,19 @@ public class SplitChat {
         ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
         layoutParams.width = matchParent ? ViewGroup.LayoutParams.MATCH_PARENT : ViewGroup.LayoutParams.WRAP_CONTENT;
         view.setLayoutParams(layoutParams);
+    }
+
+    /** called after Twitch removes the first N Messages from the buffer */
+    public static void removedNMessages(int n) {
+        Log.d(TAG, "removedNMessages(" + n + "): prev=" + totalRemovedMessages + ", after=" + (totalRemovedMessages + n));
+        totalRemovedMessages += n;
+    }
+
+    private static boolean shouldTintBG(int positionInAdapter) {
+        // see comment on totalRemovedMessages to see why we do this
+        int totalPosition = positionInAdapter + totalRemovedMessages;
+        Log.d(TAG, "shouldTintBG() positionInAdapter: " + positionInAdapter + " totalRemovedMessages: " + totalRemovedMessages + " totalPosition:" + totalPosition);
+        return totalPosition % 2 == 1;
     }
 
     private static void reset(View view) {

--- a/mod/app/src/main/java/bttv/Util.java
+++ b/mod/app/src/main/java/bttv/Util.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/mod/app/src/main/java/bttv/api/SplitChat.java
+++ b/mod/app/src/main/java/bttv/api/SplitChat.java
@@ -17,4 +17,13 @@ public class SplitChat {
         }
     }
 
+    /** Called in ChannelChatAdapter.addItems() */
+    public static void removedNMessages(int n) {
+        try {
+            bttv.SplitChat.removedNMessages(n);
+        } catch (Throwable t) {
+            Log.e(TAG, "removedNMessages: ", t);
+        }
+    }
+
 }

--- a/patches/tv.twitch.android.shared.chat.adapter.ChannelChatAdapter.smali.patch
+++ b/patches/tv.twitch.android.shared.chat.adapter.ChannelChatAdapter.smali.patch
@@ -1,0 +1,14 @@
+diff --git a/smali_classes6/tv/twitch/android/shared/chat/adapter/ChannelChatAdapter.smali b/smali_classes6/tv/twitch/android/shared/chat/adapter/ChannelChatAdapter.smali
+--- a/smali_classes6/tv/twitch/android/shared/chat/adapter/ChannelChatAdapter.smali
++++ b/smali_classes6/tv/twitch/android/shared/chat/adapter/ChannelChatAdapter.smali
+@@ -347,6 +347,10 @@
+ 
+     goto :goto_0
+ 
++    # BTTV
++    invoke-static {v0}, Lbttv/api/SplitChat;->removedNMessages(I)V
++    # /BTTV
++
+     .line 200
+     :cond_1
+     invoke-virtual {p0, v1, v0}, Landroidx/recyclerview/widget/RecyclerView$Adapter;->notifyItemRangeRemoved(II)V


### PR DESCRIPTION
Fixes #321 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
We now keep track of all removed messages to calculate an "absolute" position with them. This way we do not have to rely on the position of a message in the buffer, which is subject to change.
This should fix the issues with Split Chat discussed in #321.

There might be integer overflows, but as java does not give a [ _ ] about it and as MAX_VALUE is odd and MIN_VALUE is even we should not see any issues. Not clean but simple.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
