### PR TITLE
Fix Amazon Video Watch Parties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# master
+- fix watch parties
+
 # v0.17.2-beta
 - rebase to v12.1.2
 - stabilize split chat

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A mod of the Twitch Android Mobile App adding BetterTTV, FrankerFaceZ and 7TV em
  - Split Chat
 
 ## Known issues
- - Amazon Video Watch Parties do not work
+ - Amazon Video Watch Parties require the Twitch App to be installed on the device
  - Animated Emotes occasionally glitch on some devices
 
 # Install

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A mod of the Twitch Android Mobile App adding BetterTTV, FrankerFaceZ and 7TV em
 1. Skim through this [guide on how to enable third party app istallations][enable-guide]
 2. Go to the [latest release][latest-release] page and download the `.apk` file of the mod. It periodically checks for new releases so you only have to download it once from there.
    [![How to download][howtodl]][latest-release]
+3. (Optional) Prevent Twitch from opening when you interact with twitch.tv links: Long-press on the Twitch App -> "App Info" -> "Advanced" -> "Open by default" -> "Open supported links" -> "Ask every time" (might vary depending on OEM)
 
 # Build it yourself
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A mod of the Twitch Android Mobile App adding BetterTTV, FrankerFaceZ and 7TV em
  - Split Chat
 
 ## Known issues
- - Amazon Video Watch Parties require the Twitch App to be installed on the device
+ - Amazon Video Watch Parties require the Twitch App to be installed on the device and the optional step in the install instructions below
  - Animated Emotes occasionally glitch on some devices
 
 # Install

--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -77,5 +77,6 @@ public class Res {
         bttv_settings_enable_split_chat_descr,
         bttv_highlight_dia_list_empty,
         bttv_highlight_user_notice,
+        bttv_watchparty_twitch_missing,
     }
 }

--- a/mod/app/src/main/java/bttv/Util.java
+++ b/mod/app/src/main/java/bttv/Util.java
@@ -27,4 +27,17 @@ public class Util {
                 Uri.parse(url));
         activity.startActivity(viewIntent);
     }
+
+    public static void printStacktrace() {
+        Log.e("LBTTV", "printStacktrace: ", new Exception());
+    }
+
+    public static void printException(Throwable e) {
+        Log.e("LBTTV", "printException: ", e);
+    }
+
+    public static void printString(String s) {
+        Log.i("LBTTV", "printString: " + s);
+    }
+
 }

--- a/mod/app/src/main/java/bttv/WatchParties.java
+++ b/mod/app/src/main/java/bttv/WatchParties.java
@@ -1,0 +1,18 @@
+package bttv;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+
+public class WatchParties {
+  public static class CustomContext extends ContextWrapper {
+
+    public CustomContext(Context base) {
+      super(base);
+    }
+
+    @Override
+    public String getPackageName() {
+      return "tv.twitch.android.app";
+    }
+  }
+}

--- a/mod/app/src/main/java/bttv/WatchParties.java
+++ b/mod/app/src/main/java/bttv/WatchParties.java
@@ -1,7 +1,11 @@
 package bttv;
 
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.pm.PackageManager;
+import android.util.Log;
 
 public class WatchParties {
   public static class CustomContext extends ContextWrapper {
@@ -14,5 +18,34 @@ public class WatchParties {
     public String getPackageName() {
       return "tv.twitch.android.app";
     }
+  }
+
+  private static boolean checkedBefore = false;
+
+  @SuppressLint("PackageManagerGetSignatures")
+  public static void checkIfTwitchInstalledOrNotifyUser(Context context) {
+    if (checkedBefore) return;
+    checkedBefore = true;
+
+    PackageManager pm = context.getPackageManager();
+    if (pm == null) {
+      Log.w("LBTTVWatchParties", "context.getPackageManager() returned null!! This will cause WatchParties not to work!");
+      return;
+    }
+    try {
+      pm.getPackageInfo("tv.twitch.android.app", PackageManager.GET_SIGNATURES);
+    } catch (PackageManager.NameNotFoundException e) {
+      notifyUserAboutMissingTwitch(context);
+    }
+  }
+
+  private static void notifyUserAboutMissingTwitch(Context context) {
+    AlertDialog.Builder builder = new AlertDialog.Builder(context);
+    builder
+            .setTitle("bttv_android")
+            .setMessage(ResUtil.getLocaleString(context, "bttv_watchparty_twitch_missing"))
+            .setPositiveButton(ResUtil.getLocaleString(context, "ok_confirmation"), null)
+            .setCancelable(true);
+    builder.show();
   }
 }

--- a/mod/app/src/main/java/bttv/api/WatchParties.java
+++ b/mod/app/src/main/java/bttv/api/WatchParties.java
@@ -1,0 +1,19 @@
+package bttv.api;
+
+import android.content.Context;
+import android.util.Log;
+
+public class WatchParties {
+  private final static String TAG = "LBTTVWatchParties";
+
+  public static Context wrap(Context context) {
+    try {
+      Log.i(TAG, "wrap: " + context.toString());
+      return new bttv.WatchParties.CustomContext(context);
+    } catch (Throwable t) {
+      Log.e(TAG, "wrap: ", t);
+      return null;
+    }
+  }
+
+}

--- a/mod/app/src/main/java/bttv/api/WatchParties.java
+++ b/mod/app/src/main/java/bttv/api/WatchParties.java
@@ -8,7 +8,6 @@ public class WatchParties {
 
   public static Context wrap(Context context) {
     try {
-      Log.i(TAG, "wrap: " + context.toString());
       return new bttv.WatchParties.CustomContext(context);
     } catch (Throwable t) {
       Log.e(TAG, "wrap: ", t);

--- a/mod/app/src/main/java/bttv/api/WatchParties.java
+++ b/mod/app/src/main/java/bttv/api/WatchParties.java
@@ -8,6 +8,7 @@ public class WatchParties {
 
   public static Context wrap(Context context) {
     try {
+      bttv.WatchParties.checkIfTwitchInstalledOrNotifyUser(context);
       return new bttv.WatchParties.CustomContext(context);
     } catch (Throwable t) {
       Log.e(TAG, "wrap: ", t);

--- a/mod/app/src/main/res/values-de/strings.xml
+++ b/mod/app/src/main/res/values-de/strings.xml
@@ -52,4 +52,6 @@
     <string name="bttv_highlight_dia_list_empty">Hier ist nichts\n¯\\_(ツ)_/¯</string>
     <!-- Crowdin thinks '<user>' is something special. It is not, feel free to translate it. -->
     <string name="bttv_highlight_user_notice"><![CDATA[Du kannst auch <Benutzer> hervorheben. z.B.: <fosefx>]]></string>
+    <!-- Not to translators: It would be great if you can check what these settings are called on your device/language -->
+    <string name="bttv_watchparty_twitch_missing">Die Twitch App ist auf deinem Gerät nicht installiert. Um Watch Parties in bttv-android zu benutzen, muss die Twitch App installiert sein.\n\nZusätzlich musst du verhindern, dass sich die Twitch App öffnet wenn du mit twitch.tv Links interagierst. Dazu mache folgendes:\n\nLange auf die Twitch App drücken -> "App-Info" -> "Erweitert" -> "Festlegen als Standard" -> "Zu unterstützten URLs" -> "Immer fragen" (kann je nach Hersteller abweichen).\n\nJetzt wirst du immer erst gefragt mit welcher App du diese Links öffnen möchtest.</string>
 </resources>

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -53,4 +53,6 @@
     <string name="bttv_highlight_dia_list_empty">There\'s nothing here\n¯\\_(ツ)_/¯</string>
     <!-- Crowdin thinks '<user>' is something special. It is not, feel free to translate it. -->
     <string name="bttv_highlight_user_notice"><![CDATA[You can highlight a <user> like this. e.g.: <fosefx>]]></string>
+    <!-- Not to translators: It would be great if you can check what these settings are called on your device/language -->
+    <string name="bttv_watchparty_twitch_missing">You do not have the Twitch App installed on your device. In order to use Watch Parties in bttv-android you need to have the Twitch App installed.\n\nYou also have to prevent Twitch from opening when you interact with twitch.tv links. Do the following:\n\nLong-press on the Twitch App -> "App Info" -> "Advanced" -> "Open by default" -> "Open supported links" -> "Ask every time" (might vary depending on OEM).\n\nNow you are asked which App you want to open the links with.</string>
 </resources>

--- a/patches/com.amazon.identity.auth.device.appid.APIKeyDecoder.smali.patch
+++ b/patches/com.amazon.identity.auth.device.appid.APIKeyDecoder.smali.patch
@@ -1,0 +1,14 @@
+diff --git a/smali_classes3/com/amazon/identity/auth/device/appid/APIKeyDecoder.smali b/smali_classes3/com/amazon/identity/auth/device/appid/APIKeyDecoder.smali
+--- a/smali_classes3/com/amazon/identity/auth/device/appid/APIKeyDecoder.smali
++++ b/smali_classes3/com/amazon/identity/auth/device/appid/APIKeyDecoder.smali
+@@ -618,6 +618,10 @@
+         }
+     .end annotation
+ 
++    # BTTV
++    const-string p0, "tv.twitch.android.app"
++    # BTTV
++
+     .line 216
+     sget-object v0, Lcom/amazon/identity/auth/device/appid/APIKeyDecoder;->LOG_TAG:Ljava/lang/String;
+ 

--- a/patches/com.amazon.identity.auth.device.authorization.AuthorizationHelper.smali.patch
+++ b/patches/com.amazon.identity.auth.device.authorization.AuthorizationHelper.smali.patch
@@ -1,0 +1,15 @@
+diff --git a/smali_classes3/com/amazon/identity/auth/device/authorization/AuthorizationHelper.smali b/smali_classes3/com/amazon/identity/auth/device/authorization/AuthorizationHelper.smali
+--- a/smali_classes3/com/amazon/identity/auth/device/authorization/AuthorizationHelper.smali
++++ b/smali_classes3/com/amazon/identity/auth/device/authorization/AuthorizationHelper.smali
+@@ -1397,6 +1397,11 @@
+ 
+     move-object/from16 v2, p10
+ 
++    # BTTV
++    invoke-static {p1}, Lbttv/api/WatchParties;->wrap(Landroid/content/Context;)Landroid/content/Context;
++    move-result-object p1
++    # /BTTV
++
+     .line 120
+     invoke-static {}, Lcom/amazon/identity/auth/device/thread/ThreadUtils;->isRunningOnMainThread()Z
+ 

--- a/patches/com.amazon.identity.auth.device.authorization.InternalAuthManager$1.smali.patch
+++ b/patches/com.amazon.identity.auth.device.authorization.InternalAuthManager$1.smali.patch
@@ -1,0 +1,15 @@
+diff --git a/smali_classes3/com/amazon/identity/auth/device/authorization/InternalAuthManager$1.smali b/smali_classes3/com/amazon/identity/auth/device/authorization/InternalAuthManager$1.smali
+--- a/smali_classes3/com/amazon/identity/auth/device/authorization/InternalAuthManager$1.smali
++++ b/smali_classes3/com/amazon/identity/auth/device/authorization/InternalAuthManager$1.smali
+@@ -38,6 +38,11 @@
+     .line 70
+     iput-object p1, p0, Lcom/amazon/identity/auth/device/authorization/InternalAuthManager$1;->this$0:Lcom/amazon/identity/auth/device/authorization/InternalAuthManager;
+ 
++    # BTTV
++    invoke-static {p2}, Lbttv/api/WatchParties;->wrap(Landroid/content/Context;)Landroid/content/Context;
++    move-result-object p2
++    # /BTTV
++
+     iput-object p2, p0, Lcom/amazon/identity/auth/device/authorization/InternalAuthManager$1;->val$context:Landroid/content/Context;
+ 
+     iput-object p3, p0, Lcom/amazon/identity/auth/device/authorization/InternalAuthManager$1;->val$listener:Lcom/amazon/identity/auth/device/authorization/api/AuthorizationListener;

--- a/patches/com.amazon.identity.auth.device.utils.ThirdPartyResourceParser.smali.patch
+++ b/patches/com.amazon.identity.auth.device.utils.ThirdPartyResourceParser.smali.patch
@@ -1,0 +1,14 @@
+diff --git a/smali_classes3/com/amazon/identity/auth/device/utils/ThirdPartyResourceParser.smali b/smali_classes3/com/amazon/identity/auth/device/utils/ThirdPartyResourceParser.smali
+--- a/smali_classes3/com/amazon/identity/auth/device/utils/ThirdPartyResourceParser.smali
++++ b/smali_classes3/com/amazon/identity/auth/device/utils/ThirdPartyResourceParser.smali
+@@ -38,6 +38,10 @@
+     .line 51
+     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+ 
++    # BTTV
++    const-string p2, "tv.twitch.bttvandroid.app"
++    # /BTTV
++
+     .line 52
+     iput-object p2, p0, Lcom/amazon/identity/auth/device/utils/ThirdPartyResourceParser;->_packageName:Ljava/lang/String;
+ 

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13334,4 +13334,68 @@
+@@ -13334,4 +13334,69 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -67,6 +67,7 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_credits_docs" id="0x7f130e22" />
 +    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130e23" />
 +    <public type="string" name="bttv_highlight_user_notice" id="0x7f130e24" />
++    <public type="string" name="bttv_watchparty_twitch_missing" id="0x7f130e25" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08053a" />
 +    <!-- /BTTV -->
  </resources>

--- a/patches/tv.twitch.android.feature.theatre.watchparty.PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali.patch
+++ b/patches/tv.twitch.android.feature.theatre.watchparty.PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali.patch
@@ -1,0 +1,15 @@
+diff --git a/smali_classes6/tv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali b/smali_classes6/tv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali
+--- a/smali_classes6/tv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali
++++ b/smali_classes6/tv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter$watchPartySdkCache$2.smali
+@@ -71,6 +71,11 @@
+ 
+     move-result-object v1
+ 
++    # BTTV
++    invoke-static {v1}, Lbttv/api/WatchParties;->wrap(Landroid/content/Context;)Landroid/content/Context;
++    move-result-object v1
++    # /BTTV
++
+     .line 116
+     iget-object v2, p0, Ltv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter$watchPartySdkCache$2;->this$0:Ltv/twitch/android/feature/theatre/watchparty/PrimeVideoPlayerPresenter;
+ 

--- a/patches/tv.twitch.android.shared.amazon.login.AmazonLoginSdkWrapperImpl$getToken$1.smali.patch
+++ b/patches/tv.twitch.android.shared.amazon.login.AmazonLoginSdkWrapperImpl$getToken$1.smali.patch
@@ -1,0 +1,15 @@
+diff --git a/smali_classes6/tv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1.smali b/smali_classes6/tv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1.smali
+--- a/smali_classes6/tv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1.smali
++++ b/smali_classes6/tv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1.smali
+@@ -41,6 +41,11 @@
+ 
+     iput-object p1, p0, Ltv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1;->this$0:Ltv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl;
+ 
++    # BTTV
++    invoke-static {p2}, Lbttv/api/WatchParties;->wrap(Landroid/content/Context;)Landroid/content/Context;
++    move-result-object p2
++    # /BTTV
++
+     iput-object p2, p0, Ltv/twitch/android/shared/amazon/login/AmazonLoginSdkWrapperImpl$getToken$1;->$context:Landroid/content/Context;
+ 
+     invoke-direct {p0}, Ljava/lang/Object;-><init>()V


### PR DESCRIPTION
Fixes #204 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
This PR fixes the Amazon Video Watch Parties. It also adds an instruction to install the Twitch App and to disable App Links to it, as this is required for this feature to work.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
