### PR TITLE
Uptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # master
 - fix watch parties
+- add "Show Uptime" option
 
 # v0.17.2-beta
 - rebase to v12.1.2

--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -66,6 +66,7 @@ public class Res {
         bttv_settings_gif_render_mode_disabled,
         bttv_settings_open_credits_button_title,
         bttv_settings_enable_show_deleted_messages,
+        bttv_settings_show_uptime,
         bttv_credits_title,
         bttv_credits_intro,
         bttv_credits_bugs,

--- a/mod/app/src/main/java/bttv/Uptime.java
+++ b/mod/app/src/main/java/bttv/Uptime.java
@@ -1,6 +1,15 @@
 package bttv;
 
+import android.os.Handler;
+import android.text.format.DateUtils;
 import android.util.Log;
+import android.widget.TextView;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import tv.twitch.android.models.streams.StreamModel;
 import tv.twitch.android.models.streams.StreamType;
@@ -9,37 +18,110 @@ import tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate;
 
 public class Uptime {
   private final static String TAG = "LBTTVUptime";
+  private final static Clock clock = new Clock();
 
-  public static void replaceLiveIndicatorWithUptime(StreamModel streamModel, PlayerOverlayViewDelegate playerOverlayViewDelegate) {
+  public static void replaceLiveIndicatorWithUptime(StreamModel streamModel, PlayerOverlayViewDelegate playerOverlayViewDelegate) throws NullPointerException {
+    if (!prepareClock(streamModel, playerOverlayViewDelegate)) {
+      clock.cancelExistingSchedule();
+      playerOverlayViewDelegate.BTTVgetBottomPlayerControlOverlayViewDelegate().updateStreamType(StreamType.LIVE_VIDEO);
+    }
+  }
+
+  public static boolean prepareClock(StreamModel streamModel, PlayerOverlayViewDelegate playerOverlayViewDelegate) {
     if (streamModel == null) {
       Log.i(TAG, "replaceLiveIndicatorWithUptime: streamModel is null");
-      return;
+      return false;
     }
 
     if (!streamModel.getStreamType().equals(StreamType.LIVE_VIDEO)) {
       Log.d(TAG, "replaceLiveIndicatorWithUptime: stream type is not LIVE_VIDEO");
-      return;
+      return false;
     }
 
     if (playerOverlayViewDelegate == null) {
       Log.i(TAG, "replaceLiveIndicatorWithUptime: playerOverlayViewDelegate is null");
-      return;
+      return false;
     }
 
     BottomPlayerControlOverlayViewDelegate bottomVD = playerOverlayViewDelegate.BTTVgetBottomPlayerControlOverlayViewDelegate();
 
     if (bottomVD == null) {
       Log.i(TAG, "replaceLiveIndicatorWithUptime: playerOverlayViewDelegate.getBottomPlayerControlOverlayViewDelegate() returned null");
-      return;
+      return false;
     }
 
     if (bottomVD.mLiveIndicatorLeftText == null) {
       Log.i(TAG, "replaceLiveIndicatorWithUptime: mLiveIndicatorLeftText is null");
-      return;
+      return false;
     }
 
-    Log.i(TAG, "replaceLiveIndicatorWithUptime: " + streamModel.createdAt);
+    Date date = parseDate(streamModel.createdAt);
 
-    bottomVD.mLiveIndicatorLeftText.setText(streamModel.createdAt);
+    if (date == null) {
+      Log.w(TAG, "replaceLiveIndicatorWithUptime: date is null (" + streamModel.createdAt + ")");
+      return false;
+    }
+
+    Log.i(TAG, "replaceLiveIndicatorWithUptime: " + streamModel.createdAt + " " + date);
+
+    clock.textViewUpdated(bottomVD.mLiveIndicatorLeftText, secondsSince(date));
+    return true;
+  }
+
+  private static Date parseDate(String dateString) {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", java.util.Locale.US);
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    try {
+      return simpleDateFormat.parse(dateString);
+    } catch (ParseException e) {
+      return altParseDate(dateString);
+    }
+  }
+
+  private static Date altParseDate(String dateString) {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    try {
+      return simpleDateFormat.parse(dateString);
+    } catch (ParseException e) {
+      return null;
+    }
+  }
+
+  private static long secondsSince(Date date) {
+    return (new Date().getTime() - date.getTime()) / 1000;
+  }
+
+  private static class Clock {
+    private Handler handler = new Handler();
+    private TextView textView;
+    private long secondsSinceStart;
+
+    private Runnable task = new Runnable() {
+      @Override
+      public void run() {
+        Clock.this.textView.setText(secondsToString(secondsSinceStart++));
+        Clock.this.scheduleNextTick();
+      }
+    };
+
+    public void textViewUpdated(TextView textView, long secondsSinceStart) {
+      this.cancelExistingSchedule();
+      this.textView = textView;
+      this.secondsSinceStart = secondsSinceStart;
+      this.task.run();
+    }
+
+    private void scheduleNextTick() {
+      handler.postDelayed(task, 1000);
+    }
+
+    private void cancelExistingSchedule() {
+      handler.removeCallbacks(task);
+    }
+
+    private static String secondsToString(long secs) {
+      return DateUtils.formatElapsedTime(secs);
+    }
   }
 }

--- a/mod/app/src/main/java/bttv/Uptime.java
+++ b/mod/app/src/main/java/bttv/Uptime.java
@@ -1,0 +1,45 @@
+package bttv;
+
+import android.util.Log;
+
+import tv.twitch.android.models.streams.StreamModel;
+import tv.twitch.android.models.streams.StreamType;
+import tv.twitch.android.shared.player.overlay.BottomPlayerControlOverlayViewDelegate;
+import tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate;
+
+public class Uptime {
+  private final static String TAG = "LBTTVUptime";
+
+  public static void replaceLiveIndicatorWithUptime(StreamModel streamModel, PlayerOverlayViewDelegate playerOverlayViewDelegate) {
+    if (streamModel == null) {
+      Log.i(TAG, "replaceLiveIndicatorWithUptime: streamModel is null");
+      return;
+    }
+
+    if (!streamModel.getStreamType().equals(StreamType.LIVE_VIDEO)) {
+      Log.d(TAG, "replaceLiveIndicatorWithUptime: stream type is not LIVE_VIDEO");
+      return;
+    }
+
+    if (playerOverlayViewDelegate == null) {
+      Log.i(TAG, "replaceLiveIndicatorWithUptime: playerOverlayViewDelegate is null");
+      return;
+    }
+
+    BottomPlayerControlOverlayViewDelegate bottomVD = playerOverlayViewDelegate.BTTVgetBottomPlayerControlOverlayViewDelegate();
+
+    if (bottomVD == null) {
+      Log.i(TAG, "replaceLiveIndicatorWithUptime: playerOverlayViewDelegate.getBottomPlayerControlOverlayViewDelegate() returned null");
+      return;
+    }
+
+    if (bottomVD.mLiveIndicatorLeftText == null) {
+      Log.i(TAG, "replaceLiveIndicatorWithUptime: mLiveIndicatorLeftText is null");
+      return;
+    }
+
+    Log.i(TAG, "replaceLiveIndicatorWithUptime: " + streamModel.createdAt);
+
+    bottomVD.mLiveIndicatorLeftText.setText(streamModel.createdAt);
+  }
+}

--- a/mod/app/src/main/java/bttv/api/Uptime.java
+++ b/mod/app/src/main/java/bttv/api/Uptime.java
@@ -1,0 +1,20 @@
+package bttv.api;
+
+import android.util.Log;
+
+import tv.twitch.android.models.streams.StreamModel;
+import tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate;
+
+public class Uptime {
+  private final static String TAG = "LBTTVUptime";
+
+  // called in tv/twitch/android/shared/player/overlay/PlayerOverlayPresenter.bindStream()
+  public static void replaceLiveIndicatorWithUptime(StreamModel streamModel, PlayerOverlayViewDelegate playerOverlayViewDelegate) {
+    Log.i(TAG, "replaceLiveIndicatorWithUptime()");
+    try {
+      bttv.Uptime.replaceLiveIndicatorWithUptime(streamModel, playerOverlayViewDelegate);
+    } catch (Throwable t) {
+      Log.e(TAG, "replaceLiveIndicatorWithUptime: ", t);
+    }
+  }
+}

--- a/mod/app/src/main/java/bttv/settings/Settings.java
+++ b/mod/app/src/main/java/bttv/settings/Settings.java
@@ -91,6 +91,15 @@ public enum Settings {
                 null
             )
     ),
+    ShowUptime(
+          new Entry.BoolEntry(
+                  "show_uptime",
+                  new Entry.BoolValue(false),
+                  Res.strings.bttv_settings_show_uptime,
+                  null,
+                  null
+          )
+    ),
     OpenHighlightedWordsButton(
             new Entry.LinkEntry(
                 Res.strings.bttv_settings_open_highlights_dia_primary,

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="bttv_settings_enable_7tv_emotes_primary">7TV Emotes</string>
     <string name="bttv_settings_enable_auto_redeem_points_primary">Auto-Redeem Channel Points</string>
     <string name="bttv_settings_show_sleep_timer_primary">Show Sleep Timer</string>
+    <string name="bttv_settings_show_uptime">Show Uptime</string>
     <string name="bttv_emote_added_by_bttv">Emote added by bttv-android</string>
     <!-- e.g.: FrankerFaceZ Emote added by FoseFx -->
     <string name="bttv_emote_added_by_bttv_ffz">FrankerFaceZ Emote added by %s</string>

--- a/mod/twitch/src/main/java/tv/twitch/android/models/streams/StreamModel.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/models/streams/StreamModel.java
@@ -1,0 +1,9 @@
+package tv.twitch.android.models.streams;
+
+public class StreamModel {
+  public String createdAt;
+
+  public tv.twitch.android.models.streams.StreamType getStreamType() {
+    throw new IllegalStateException("tv.twitch.android.models.streams.getStreamType() stub was called");
+  }
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/models/streams/StreamType.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/models/streams/StreamType.java
@@ -1,0 +1,6 @@
+package tv.twitch.android.models.streams;
+
+public enum StreamType {
+  LIVE_VIDEO("live");
+  private StreamType(String str) {}
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.java
@@ -1,0 +1,5 @@
+package tv.twitch.android.shared.player.overlay;
+
+public class BottomPlayerControlOverlayViewDelegate {
+  public android.widget.TextView mLiveIndicatorLeftText;
+}

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.java
@@ -1,5 +1,8 @@
 package tv.twitch.android.shared.player.overlay;
 
+import tv.twitch.android.models.streams.StreamType;
+
 public class BottomPlayerControlOverlayViewDelegate {
   public android.widget.TextView mLiveIndicatorLeftText;
+  public void updateStreamType(StreamType streamType) {}
 }

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.java
@@ -1,0 +1,7 @@
+package tv.twitch.android.shared.player.overlay;
+
+public class PlayerOverlayViewDelegate {
+  public final BottomPlayerControlOverlayViewDelegate BTTVgetBottomPlayerControlOverlayViewDelegate() {
+    throw new IllegalStateException("tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate.getBottomPlayerControlOverlayViewDelegate() stub was called");
+  }
+}

--- a/patches/AndroidManifest.xml.patch
+++ b/patches/AndroidManifest.xml.patch
@@ -26,6 +26,15 @@ diff --git a/AndroidManifest.xml b/AndroidManifest.xml
      <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:required="false"/>
      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:required="false"/>
      <uses-feature android:name="android.hardware.camera" android:required="false"/>
+@@ -56,7 +68,7 @@
+     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+     <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
+-    <application android:allowBackup="false" android:appComponentFactory="androidx.core.app.CoreComponentFactory" android:enabled="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:largeHeap="true" android:name="tv.twitch.android.app.consumer.TwitchApplication" android:networkSecurityConfig="@xml/default_security_config" android:requestLegacyExternalStorage="false" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/Theme.TwitchApp">
++    <application android:debuggable="true" android:allowBackup="false" android:appComponentFactory="androidx.core.app.CoreComponentFactory" android:enabled="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:largeHeap="true" android:name="tv.twitch.android.app.consumer.TwitchApplication" android:networkSecurityConfig="@xml/default_security_config" android:requestLegacyExternalStorage="false" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/Theme.TwitchApp">
+         <meta-data android:name="WindowManagerPreference:FreeformWindowSize" android:value="phone"/>
+         <meta-data android:name="WindowManagerPreference:FreeformWindowOrientation" android:value="portrait"/>
+         <meta-data android:name="android.allow_multiple_resumed_activities" android:value="true"/>
 @@ -156,10 +168,10 @@
              </intent-filter>
          </receiver>

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13334,4 +13334,69 @@
+@@ -13334,4 +13334,70 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -59,15 +59,16 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_settings_enable_show_deleted_messages" id="0x7f130e1a" />
 +    <public type="string" name="bttv_settings_enable_split_chat" id="0x7f130e1b" />
 +    <public type="string" name="bttv_settings_enable_split_chat_descr" id="0x7f130e1c" />
-+    <public type="string" name="bttv_credits_title" id="0x7f130e1d" />
-+    <public type="string" name="bttv_credits_intro" id="0x7f130e1e" />
-+    <public type="string" name="bttv_credits_bugs" id="0x7f130e1f" />
-+    <public type="string" name="bttv_credits_ideas" id="0x7f130e20" />
-+    <public type="string" name="bttv_credits_translations" id="0x7f130e21" />
-+    <public type="string" name="bttv_credits_docs" id="0x7f130e22" />
-+    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130e23" />
-+    <public type="string" name="bttv_highlight_user_notice" id="0x7f130e24" />
-+    <public type="string" name="bttv_watchparty_twitch_missing" id="0x7f130e25" />
++    <public type="string" name="bttv_settings_show_uptime" id="0x7f130e1d" />
++    <public type="string" name="bttv_credits_title" id="0x7f130e1e" />
++    <public type="string" name="bttv_credits_intro" id="0x7f130e1f" />
++    <public type="string" name="bttv_credits_bugs" id="0x7f130e20" />
++    <public type="string" name="bttv_credits_ideas" id="0x7f130e21" />
++    <public type="string" name="bttv_credits_translations" id="0x7f130e22" />
++    <public type="string" name="bttv_credits_docs" id="0x7f130e23" />
++    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130e24" />
++    <public type="string" name="bttv_highlight_user_notice" id="0x7f130e25" />
++    <public type="string" name="bttv_watchparty_twitch_missing" id="0x7f130e26" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08053a" />
 +    <!-- /BTTV -->
  </resources>

--- a/patches/tv.twitch.android.models.streams.StreamModel.smali.patch
+++ b/patches/tv.twitch.android.models.streams.StreamModel.smali.patch
@@ -1,0 +1,12 @@
+diff --git a/smali_classes6/tv/twitch/android/models/streams/StreamModel.smali b/smali_classes6/tv/twitch/android/models/streams/StreamModel.smali
+--- a/smali_classes6/tv/twitch/android/models/streams/StreamModel.smali
++++ b/smali_classes6/tv/twitch/android/models/streams/StreamModel.smali
+@@ -57,7 +57,7 @@
+     .end annotation
+ .end field
+ 
+-.field private createdAt:Ljava/lang/String;
++.field public createdAt:Ljava/lang/String; # BTTV: private -> public
+ 
+ .field private delay:I
+ 

--- a/patches/tv.twitch.android.shared.player.overlay.BottomPlayerControlOverlayViewDelegate.smali.patch
+++ b/patches/tv.twitch.android.shared.player.overlay.BottomPlayerControlOverlayViewDelegate.smali.patch
@@ -1,6 +1,15 @@
 diff --git a/smali_classes7/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali b/smali_classes7/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali
 --- a/smali_classes7/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali
 +++ b/smali_classes7/tv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate.smali
+@@ -22,7 +22,7 @@
+ 
+ .field private final mLiveIndicatorImageView:Landroid/widget/ImageView;
+ 
+-.field private final mLiveIndicatorLeftText:Landroid/widget/TextView;
++.field public final mLiveIndicatorLeftText:Landroid/widget/TextView; # BTTV: private -> public
+ 
+ .field private final mOverlayFloatRightText:Landroid/widget/TextView;
+ 
 @@ -126,6 +126,13 @@
      .line 70
      invoke-direct {p0, p1, p2}, Ltv/twitch/android/core/mvp/viewdelegate/BaseViewDelegate;-><init>(Landroid/content/Context;Landroid/view/View;)V

--- a/patches/tv.twitch.android.shared.player.overlay.PlayerOverlayPresenter.smali.patch
+++ b/patches/tv.twitch.android.shared.player.overlay.PlayerOverlayPresenter.smali.patch
@@ -1,0 +1,14 @@
+diff --git a/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayPresenter.smali b/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayPresenter.smali
+--- a/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayPresenter.smali
++++ b/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayPresenter.smali
+@@ -655,6 +655,10 @@
+ 
+     invoke-virtual {v0, v1}, Ltv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate;->updateStreamType(Ltv/twitch/android/models/streams/StreamType;)V
+ 
++    # BTTV
++    invoke-static {p1, v0}, Lbttv/api/Uptime;->replaceLiveIndicatorWithUptime(Ltv/twitch/android/models/streams/StreamModel;Ltv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate;)V
++    # /BTTV
++
+     .line 284
+     :cond_1
+     iget-object v0, p0, Ltv/twitch/android/shared/player/overlay/PlayerOverlayPresenter;->viewDelegate:Ltv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate;

--- a/patches/tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate.smali.patch
+++ b/patches/tv.twitch.android.shared.player.overlay.PlayerOverlayViewDelegate.smali.patch
@@ -1,0 +1,22 @@
+diff --git a/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.smali b/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.smali
+--- a/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.smali
++++ b/smali_classes7/tv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate.smali
+@@ -561,6 +561,18 @@
+     return-object v0
+ .end method
+ 
++# BTTV
++.method public BTTVgetBottomPlayerControlOverlayViewDelegate()Ltv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate;
++    .locals 1
++
++    iget-object v0, p0, Ltv/twitch/android/shared/player/overlay/PlayerOverlayViewDelegate;->bottomPlayerControlOverlayViewDelegate$delegate:Lkotlin/Lazy;
++    invoke-interface {v0}, Lkotlin/Lazy;->getValue()Ljava/lang/Object;
++    move-result-object v0
++    check-cast v0, Ltv/twitch/android/shared/player/overlay/BottomPlayerControlOverlayViewDelegate;
++    return-object v0
++.end method
++# /BTTV
++
+ .method private final getChromecastLabel(Ljava/lang/String;)Ljava/lang/CharSequence;
+     .locals 12
+ 


### PR DESCRIPTION
Fixes #192 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
Replaces the "Live" indicator with the time the stream is live.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes acording to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
