### PR TITLE
add show devtools settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# master
+- add devtools toggle
+
 # v0.19.0-beta
 - add anon chat
 - add some bttv-android settings to stream settings

--- a/genmonke
+++ b/genmonke
@@ -137,3 +137,7 @@ mv res.drawable-v23.background_splash.xml.patch ui/.
 mv res.mipmap-anydpi-v26.ic_launcher.xml.patch ui/.
 mv res.layout.settings_logout_footer.xml.patch ui/.
 
+# DevTools
+mkdir devtools
+mv tv.twitch.android.feature.viewer.main.navigation.ToolbarPresenter.smali.patch devtools/.
+

--- a/mod/app/src/main/java/bttv/DevTools.java
+++ b/mod/app/src/main/java/bttv/DevTools.java
@@ -1,0 +1,39 @@
+package bttv;
+
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import bttv.settings.Settings;
+
+public class DevTools {
+    private static final String TAG = "LBTTVDevTools";
+
+    public static void maybeShowDevTools(Menu menu) {
+        if (!ResUtil.getBooleanFromSettings(Settings.DevToolsEnabled)) {
+            return;
+        }
+
+        Res.ids[] ids = new Res.ids[]{
+                Res.ids.debug_experiment_dialog,
+                Res.ids.ad_debug_settings,
+                Res.ids.commerce_settings,
+                Res.ids.creator_settings,
+                Res.ids.community_settings,
+                Res.ids.latency_injection_settings,
+        };
+        for (Res.ids id : ids) {
+            int intid = ResUtil.getResourceId(Data.ctx, id);
+            if (intid == -1) {
+                Log.w(TAG, "maybeShowDevTools: intid is -1 for " + id);
+                continue;
+            }
+            MenuItem menuItem = menu.findItem(intid);
+            if (menuItem == null) {
+                Log.w(TAG, "maybeShowDevTools: menuItem is null for " + id + " intid: " + intid);
+                continue;
+            }
+            menuItem.setVisible(true);
+        }
+    }
+}

--- a/mod/app/src/main/java/bttv/Res.java
+++ b/mod/app/src/main/java/bttv/Res.java
@@ -6,6 +6,12 @@ public class Res {
         bttv_sonic
     }
     public enum ids {
+        debug_experiment_dialog,
+        ad_debug_settings,
+        commerce_settings,
+        creator_settings,
+        community_settings,
+        latency_injection_settings,
         bttv_updater_activity_title,
         bttv_updater_activity_body,
         bttv_updater_activity_pb,
@@ -78,6 +84,8 @@ public class Res {
         bttv_settings_enable_anon_chat_primary,
         bttv_settings_enable_anon_chat_secondary,
         bttv_settings_show_uptime,
+        bttv_settings_enable_dev_tools,
+        bttv_settings_enable_dev_tools_secondary,
         bttv_credits_title,
         bttv_credits_intro,
         bttv_credits_bugs,

--- a/mod/app/src/main/java/bttv/api/DevTools.java
+++ b/mod/app/src/main/java/bttv/api/DevTools.java
@@ -1,0 +1,19 @@
+package bttv.api;
+
+import android.util.Log;
+import android.view.Menu;
+
+public class DevTools {
+
+    private static final String TAG = "LBTTVDevTools";
+
+    // called in ToolbarPresenter.onMenuCreated()
+    public static void maybeShowDevTools(Menu menu) {
+        try {
+            Log.d(TAG, "maybeShowDevTools: " + menu);
+            bttv.DevTools.maybeShowDevTools(menu);
+        } catch (Throwable t) {
+            Log.e(TAG, "maybeShowDevTools: ", t);
+        }
+    }
+}

--- a/mod/app/src/main/java/bttv/settings/Settings.java
+++ b/mod/app/src/main/java/bttv/settings/Settings.java
@@ -126,6 +126,15 @@ public enum Settings {
                     null
             )
     ),
+    DevToolsEnabled(
+            new Entry.BoolEntry(
+                    "bttv_enable_dev_tools",
+                    new Entry.BoolValue(false),
+                    Res.strings.bttv_settings_enable_dev_tools,
+                    Res.strings.bttv_settings_enable_dev_tools_secondary,
+                    null
+            )
+    ),
     OpenCreditsButton(
             new Entry.LinkEntry(
                     Res.strings.bttv_settings_open_credits_button_title,

--- a/mod/app/src/main/res/values/strings.xml
+++ b/mod/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="bttv_settings_enable_split_chat_descr">Tint the background of every second chat message</string>
     <string name="bttv_settings_gif_render_mode_animate_forever">Animate forever</string>
     <string name="bttv_settings_gif_render_mode_descr">Note: "Animate forever" might drain your battery really fast</string>
+    <string name="bttv_settings_enable_dev_tools">Enable Developer Tools</string>
+    <string name="bttv_settings_enable_dev_tools_secondary">Manage experiments, latency and other settings. Proceed with caution.</string>
     <string name="bttv_highlight_dia_list_empty">There\'s nothing here\n¯\\_(ツ)_/¯</string>
     <!-- Crowdin thinks '<user>' is something special. It is not, feel free to translate it. -->
     <string name="bttv_highlight_user_notice"><![CDATA[You can highlight a <user> like this. e.g.: <fosefx>]]></string>

--- a/patches/devtools/tv.twitch.android.feature.viewer.main.navigation.ToolbarPresenter.smali.patch
+++ b/patches/devtools/tv.twitch.android.feature.viewer.main.navigation.ToolbarPresenter.smali.patch
@@ -1,0 +1,14 @@
+diff --git a/smali_classes6/tv/twitch/android/feature/viewer/main/navigation/ToolbarPresenter.smali b/smali_classes6/tv/twitch/android/feature/viewer/main/navigation/ToolbarPresenter.smali
+--- a/smali_classes6/tv/twitch/android/feature/viewer/main/navigation/ToolbarPresenter.smali
++++ b/smali_classes6/tv/twitch/android/feature/viewer/main/navigation/ToolbarPresenter.smali
+@@ -2318,6 +2318,10 @@
+     .line 378
+     invoke-direct {p0, p1}, Ltv/twitch/android/feature/viewer/main/navigation/ToolbarPresenter;->updateSearchVisibilityForCreatorMode(Landroid/view/Menu;)V
+ 
++    # BTTV
++    invoke-static {p1}, Lbttv/api/DevTools;->maybeShowDevTools(Landroid/view/Menu;)V
++    # /BTTV
++
+     return-void
+ .end method
+ 

--- a/patches/res.values.public.xml.patch
+++ b/patches/res.values.public.xml.patch
@@ -1,7 +1,7 @@
 diff --git a/res/values/public.xml b/res/values/public.xml
 --- a/res/values/public.xml
 +++ b/res/values/public.xml
-@@ -13334,4 +13334,81 @@
+@@ -13334,4 +13334,83 @@
      <public type="xml" name="standalone_badge_offset" id="0x7f160007" />
      <public type="xml" name="syncadapter" id="0x7f160008" />
      <public type="xml" name="splits0" id="0x7f160009" />
@@ -71,15 +71,17 @@ diff --git a/res/values/public.xml b/res/values/public.xml
 +    <public type="string" name="bttv_settings_show_uptime" id="0x7f130e1d" />
 +    <public type="string" name="bttv_settings_enable_anon_chat_primary" id="0x7f130e1e" />
 +    <public type="string" name="bttv_settings_enable_anon_chat_secondary" id="0x7f130e1f" />
-+    <public type="string" name="bttv_credits_title" id="0x7f130e20" />
-+    <public type="string" name="bttv_credits_intro" id="0x7f130e21" />
-+    <public type="string" name="bttv_credits_bugs" id="0x7f130e22" />
-+    <public type="string" name="bttv_credits_ideas" id="0x7f130e23" />
-+    <public type="string" name="bttv_credits_translations" id="0x7f130e24" />
-+    <public type="string" name="bttv_credits_docs" id="0x7f130e25" />
-+    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130e26" />
-+    <public type="string" name="bttv_highlight_user_notice" id="0x7f130e27" />
-+    <public type="string" name="bttv_watchparty_twitch_missing" id="0x7f130e28" />
++    <public type="string" name="bttv_settings_enable_dev_tools" id="0x7f130e20" />
++    <public type="string" name="bttv_settings_enable_dev_tools_secondary" id="0x7f130e21" />
++    <public type="string" name="bttv_credits_title" id="0x7f130e22" />
++    <public type="string" name="bttv_credits_intro" id="0x7f130e23" />
++    <public type="string" name="bttv_credits_bugs" id="0x7f130e24" />
++    <public type="string" name="bttv_credits_ideas" id="0x7f130e25" />
++    <public type="string" name="bttv_credits_translations" id="0x7f130e26" />
++    <public type="string" name="bttv_credits_docs" id="0x7f130e27" />
++    <public type="string" name="bttv_highlight_dia_list_empty" id="0x7f130e28" />
++    <public type="string" name="bttv_highlight_user_notice" id="0x7f130e29" />
++    <public type="string" name="bttv_watchparty_twitch_missing" id="0x7f130e2a" />
 +    <public type="drawable" name="bttv_ic_bedtime" id="0x7f08053a" />
 +    <!-- /BTTV -->
  </resources>


### PR DESCRIPTION
Fixes #372 <!-- If applicable -->

## Changes
<!-- What does this PR change? -->
add a toggle that makes some devtools visible, including experiments and latency control

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
