### PR TITLE
use webp for bttv

### DIFF
--- a/mod/app/src/main/java/bttv/emote/Emote.java
+++ b/mod/app/src/main/java/bttv/emote/Emote.java
@@ -16,7 +16,7 @@ public class Emote {
     public Emotes.Source source;
     public String code;
     public String url;
-    public String imageType;
+    public String imageType; // this is really only used to start the Gif if it is a Gif
     public String owner;
 
     public Emote(String id, Emotes.Source source, String code, String url, String imageType, String owner) {
@@ -38,7 +38,7 @@ public class Emote {
         switch (source) {
             case BTTV:
                 code = jsonObject.getString("code");
-                url = "https://cdn.betterttv.net/emote/" + id + "/2x";
+                url = "https://cdn.betterttv.net/emote/" + id + "/2x.webp";
                 imageType = jsonObject.getString("imageType");
                 owner = null; // we don't get the owner :/
                 break;


### PR DESCRIPTION

Fixes #583<!-- If applicable -->

## Changes
<!-- What does this PR change? -->
- uses bttv's new webp api

Blocked by #199

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [ ] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
