### PR TITLE
Move to 7TV API v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# master
+- move to 7TV API v3
+- remove support for 7TV badges
+
 # 0.40.1-beta 
 - rebase to v15.4.1
 

--- a/mod/app/src/main/java/bttv/Badges.java
+++ b/mod/app/src/main/java/bttv/Badges.java
@@ -94,7 +94,12 @@ public class Badges {
     public static void getBadges() {
         Network.get(Network.BTTV_API_HOST + "/3/cached/badges", new ResponseHandler(BTTVBadgeKind.BTTV));
         Network.get(Network.FFZ_API_HOST + "/badges/ids", new ResponseHandler(BTTVBadgeKind.FFZ));
-        Network.get(Network.STV_API_HOST + "/cosmetics?user_identifier=twitch_id", new ResponseHandler(BTTVBadgeKind.STV));
+        // Since API v3 7TV does cosmetics in an event-driven way,
+        // Once a user joins, their presence, along their cosmetics is populated to us
+        // this would require us to keep a connection to 7TV and wait for presence updates,
+        // which is expensive in terms of CPU usage, so we are not doing that.
+        // 7TV Badges are deprecated
+        // Network.get(Network.STV_API_HOST + "/cosmetics?user_identifier=twitch_id", new ResponseHandler(BTTVBadgeKind.STV));
         Network.get(Network.CHATTERINO_API_HOST + "/badges", new ResponseHandler(BTTVBadgeKind.Chatterino));
     }
 

--- a/mod/app/src/main/java/bttv/Network.java
+++ b/mod/app/src/main/java/bttv/Network.java
@@ -23,7 +23,7 @@ public class Network {
     private static final int GLOBAL_CHANNEL_ID = -2;
     public static final String BTTV_API_HOST = "https://api.betterttv.net";
     public static final String FFZ_API_HOST = "https://api.frankerfacez.com/v1";
-    public static final String STV_API_HOST = "https://api.7tv.app/v2";
+    public static final String STV_API_HOST = "https://7tv.io/v3";
     public static final String CHATTERINO_API_HOST = "https://api.chatterino.com";
 
     public static void get(String url, Callback cb) {
@@ -97,7 +97,7 @@ public class Network {
     }
 
     public static void get7TVGlobalEmotes() {
-        get(STV_API_HOST + "/emotes/global", new ResponseHandler(Emotes.Source.STV, GLOBAL_CHANNEL_ID));
+        get(STV_API_HOST + "/emote-sets/global", new ResponseHandler(Emotes.Source.STV, GLOBAL_CHANNEL_ID));
     }
 
     public static void getBTTVChannelEmotes(int channelId) {
@@ -110,7 +110,7 @@ public class Network {
     }
 
     public static void get7TVChannelEmotes(int channelId) {
-        get(STV_API_HOST + "/users/" + channelId + "/emotes",
+        get(STV_API_HOST + "/users/twitch/" + channelId,
                 new ResponseHandler(Emotes.Source.STV, channelId));
     }
 

--- a/mod/app/src/main/java/bttv/emote/Emote.java
+++ b/mod/app/src/main/java/bttv/emote/Emote.java
@@ -55,26 +55,52 @@ public class Emote {
                     owner = jsonObject.getJSONObject("user").getString("displayName");
                 break;
             case STV:
-                code = jsonObject.getString("name");
-                JSONArray urls = jsonObject.getJSONArray("urls");
+                JSONObject data = jsonObject.getJSONObject("data");
+                code = data.getString("name");
 
-                JSONArray urlArr; // urlArr = ["1", "https://.."]
+                JSONObject hostObj = data.getJSONObject("host");
+                StringBuilder urlBuilder = new StringBuilder(hostObj.getString("url"));
+                urlBuilder.append('/');
 
-                if (urls.length() >= 2) {
-                    urlArr = urls.getJSONArray(1); // 2x
+                JSONArray files = hostObj.getJSONArray("files");
+
+                // the following is semantically equivalent to this:
+                // - filter out non-webp files
+                // - if length > 1 choose the second option (the 2x size, which has a height of 64)
+                //   else choose the first item (low quality)
+
+                String smallerThan64 = null;
+                String geThan64 = null;
+
+                for (int i = 0; i < files.length(); i++) {
+                    JSONObject emote = files.getJSONObject(i);
+                    if (!emote.getString("format").equals("WEBP")) {
+                        continue;
+                    }
+                    String name = emote.getString("name");
+                    if (emote.getInt("height") >= 64 && geThan64 == null) {
+                        geThan64 = name;
+                    } else if (smallerThan64 == null) {
+                        smallerThan64 = name;
+                    }
+                }
+                String selected = null;
+                if (geThan64 != null) {
+                    selected = geThan64;
                 } else {
-                    urlArr = urls.getJSONArray(0); // 1x
+                    selected = smallerThan64; // if missing, we are f'ed anyway
                 }
 
-                url = urlArr.getString(1);
+                urlBuilder.append(selected);
 
-                String mime = jsonObject.getString("mime");
-                if (mime.equals("image/gif")) {
+                url = urlBuilder.toString();
+
+                if (data.getBoolean("animated")) {
                     imageType = "gif";
                 } else {
                     imageType = "png";
                 }
-                owner = jsonObject.getJSONObject("owner").getString("display_name");
+                owner = data.getJSONObject("owner").getString("display_name");
                 break;
             default:
                 Log.w("LBTTVEmoteFromJson", "source unknown: " + source);
@@ -88,7 +114,21 @@ public class Emote {
     }
 
     public static List<Emote> fromJSONArray(String json, Emotes.Source source) throws JSONException {
-        JSONArray arr = new JSONArray(json);
+        JSONArray arr;
+        if (source == Emotes.Source.STV) {
+            JSONObject response = new JSONObject(json);
+            JSONObject emoteSet;
+            // global emotes already is only the emote set,
+            // for user-related requests get it
+            if (response.has("emote_set")) {
+                emoteSet = response.getJSONObject("emote_set");
+            } else {
+                emoteSet = response;
+            }
+            arr = emoteSet.getJSONArray("emotes");
+        } else {
+            arr = new JSONArray(json);
+        }
         return fromJSONArray(arr, source);
     }
 

--- a/mod/app/src/main/java/bttv/emote/Emote.java
+++ b/mod/app/src/main/java/bttv/emote/Emote.java
@@ -59,7 +59,8 @@ public class Emote {
                 code = data.getString("name");
 
                 JSONObject hostObj = data.getJSONObject("host");
-                StringBuilder urlBuilder = new StringBuilder(hostObj.getString("url"));
+                StringBuilder urlBuilder = new StringBuilder("https:"); // for some godforsaken reason this part is missing
+                urlBuilder.append(hostObj.getString("url"));
                 urlBuilder.append('/');
 
                 JSONArray files = hostObj.getJSONArray("files");


### PR DESCRIPTION
Fixes #633

## Changes
- moves emote to new 7tv API
- removes support for 7tv cosmetics
<!-- What does this PR change? -->

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I use the "bttv_" prefix for all resources I propose
 - [x] When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)
 - [x] If my change is significant enough, I added it to the CHANGELOG.md under `master`
 - [x] I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
