### PR TITLE
Update dependencies and tools to target API 33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
 ENV ANDROID_HOME /opt/android-sdk-linux
 ENV ANDROID_SDK /opt/android-sdk-linux
 
-RUN echo "y\n" | cmdline-tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux "build-tools;30.0.0"
+RUN echo "y\n" | cmdline-tools/bin/sdkmanager --sdk_root=/opt/android-sdk-linux "build-tools;33.0.0"
 
 # apktool
 

--- a/initworkspace
+++ b/initworkspace
@@ -11,9 +11,9 @@ STEPS=5
 [ -z "$BUILD_COMPANION" ] && BUILD_COMPANION=/opt/build-companion
 
 
-DX_PATTERN="$ANDROID_SDK_ROOT/build-tools/*/dx"
-DX_FILES=( $DX_PATTERN )
-DX=${DX_FILES[0]}
+D8_PATTERN="$ANDROID_SDK_ROOT/build-tools/*/d8"
+D8_FILES=( $D8_PATTERN )
+D8=${D8_FILES[0]}
 
 echo "=== Verifing tools (1/$STEPS) ===" &&
 echo "If an errr occurs during this step make" &&
@@ -35,8 +35,8 @@ echo "" && echo "apktool:" && echo "" &&
 $JAVA_PATH -jar $APKTOOL_PATH --version &&
 echo "" && echo "uber apk signer:" && echo "" &&
 $JAVA_PATH -jar $UBER_APK_SIGNER_PATH --version &&
-echo "" && echo "dx (android sdk build tools):" && echo "" &&
-$DX --version &&
+echo "" && echo "d8 (android sdk build tools):" && echo "" &&
+$D8 --version &&
 echo "" && echo "baksmali:" && echo "" &&
 $JAVA_PATH -jar $BAKSMALI_PATH --version &&
 echo "" &&

--- a/mod/app/build.gradle
+++ b/mod/app/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion 23
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -25,21 +25,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    namespace "bttv.mod"
 }
 
 dependencies {
     def GLIDE_VERSION = "4.12.0"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'com.google.android.material:material:1.9.0'
     api "com.github.zjupure:webpdecoder:2.0.${GLIDE_VERSION}"
     api "com.caverock:androidsvg-aar:1.4"
     implementation project(path: ':twitch')
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:1.10.19'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/mod/app/src/main/AndroidManifest.xml
+++ b/mod/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="bttv.mod">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 </manifest>

--- a/mod/app/src/main/java/bttv/glide/svg/SvgDecoder.java
+++ b/mod/app/src/main/java/bttv/glide/svg/SvgDecoder.java
@@ -3,6 +3,7 @@ package bttv.glide.svg;
 import static com.bumptech.glide.request.target.Target.SIZE_ORIGINAL;
 
 import android.util.Log;
+import android.util.TypedValue;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -45,6 +46,6 @@ public class SvgDecoder implements ResourceDecoder<InputStream, SVG> {
     }
 
     private static float dpToPx(float f) {
-        return android.util.TypedValue.applyDimension(1, f, android.content.res.Resources.getSystem().getDisplayMetrics());
+        return android.util.TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, f, android.content.res.Resources.getSystem().getDisplayMetrics());
     }
 }

--- a/mod/app/src/main/java/bttv/highlight/Blacklist.java
+++ b/mod/app/src/main/java/bttv/highlight/Blacklist.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import bttv.Res;
 import bttv.settings.Settings;
 
+import java.util.Locale;
+
 public class Blacklist extends StringSetUI {
     private static final String TAG = "LBTTVBlacklist";
     private static Blacklist INSTANCE;
@@ -21,6 +23,6 @@ public class Blacklist extends StringSetUI {
     }
     public static boolean shouldBlock(String word) {
         getInstance().loadSet();
-        return INSTANCE.stringSet.contains(word.toLowerCase());
+        return INSTANCE.stringSet.contains(word.toLowerCase(Locale.getDefault()));
     }
 }

--- a/mod/app/src/main/java/bttv/highlight/Highlight.java
+++ b/mod/app/src/main/java/bttv/highlight/Highlight.java
@@ -1,5 +1,7 @@
 package bttv.highlight;
 
+import java.util.Locale;
+
 import android.util.Log;
 
 import bttv.ChommentModelDelegateWrapper;
@@ -73,12 +75,12 @@ public class Highlight extends StringSetUI {
         getInstance().loadSet();
         if (word.startsWith("<") || word.endsWith(">"))
             return false;
-        return INSTANCE.stringSet.contains(word.toLowerCase());
+        return INSTANCE.stringSet.contains(word.toLowerCase(Locale.getDefault()));
     }
 
     public static boolean shouldHighlightChannel(String name) {
         getInstance().loadSet();
-        return INSTANCE.stringSet.contains("<" + name.toLowerCase() + ">");
+        return INSTANCE.stringSet.contains("<" + name.toLowerCase(Locale.getDefault()) + ">");
     }
 
 }

--- a/mod/app/src/main/java/bttv/highlight/StringSetUI.java
+++ b/mod/app/src/main/java/bttv/highlight/StringSetUI.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.Locale;
 
 import bttv.Data;
 import bttv.Res;
@@ -41,12 +42,12 @@ public abstract class StringSetUI {
 
 
     void remove(String word) {
-        stringSet.remove(word.toLowerCase());
+        stringSet.remove(word.toLowerCase(Locale.getDefault()));
         stringSetSetting.entry.set(Data.ctx, new UserPreferences.Entry.StringSetValue(stringSet));
     }
 
     boolean add(String word) {
-        boolean val = stringSet.add(word.toLowerCase());
+        boolean val = stringSet.add(word.toLowerCase(Locale.getDefault()));
         stringSetSetting.entry.set(Data.ctx, new UserPreferences.Entry.StringSetValue(stringSet));
         return val;
     }
@@ -122,7 +123,7 @@ public abstract class StringSetUI {
 
     boolean dialogOnAdd(TextView v, StringSetUIAdapter adapter, ArrayList<String> asList, ListView list, TextView emptyTV) {
         for (String w: v.getText().toString().split(" ")) {
-            String word = w.toLowerCase();
+            String word = w.toLowerCase(Locale.getDefault());
             if (word.trim().isEmpty()) {
                 continue;
             }

--- a/mod/app/src/main/java/bttv/updater/UpdaterJobService.java
+++ b/mod/app/src/main/java/bttv/updater/UpdaterJobService.java
@@ -121,7 +121,7 @@ public class UpdaterJobService extends JobService implements Updater.UpdateCallb
                 notificationManager.notify((int) (Math.random() * 10000), notifBuilder.build());
             } else {
                 Log.w("NotificationsPermissionsReceiver", "Permissions are not allowed, not showing notification");
-                //Twitch already asks on startup, we do not need to take care of this
+                // Twitch already asks on startup, we do not need to take care of this
             }
             jobFinished(params, false);
         } catch (Throwable e) {

--- a/mod/app/src/main/java/bttv/updater/UpdaterJobService.java
+++ b/mod/app/src/main/java/bttv/updater/UpdaterJobService.java
@@ -120,7 +120,7 @@ public class UpdaterJobService extends JobService implements Updater.UpdateCallb
 
                 notificationManager.notify((int) (Math.random() * 10000), notifBuilder.build());
             } else {
-                Log.w("NotificationsPermissionsReceiver", "Permissions are not allowed, not showing notification");
+                Log.w("LBTTVUpdaterJob", "Permissions are not allowed, not showing notification");
                 // Twitch already asks on startup, we do not need to take care of this
             }
             jobFinished(params, false);

--- a/mod/app/src/main/res/values-pt/strings.xml
+++ b/mod/app/src/main/res/values-pt/strings.xml
@@ -30,7 +30,7 @@
     <string name="bttv_updater_notice">Se esta é a primeira vez que você utiliza o atualizador, permita instalações desta fonte quando o assistente lhe pedir.</string>
     <string name="bttv_updater_manual_update_start_toast">Verificando por atualizações…</string>
     <string name="bttv_updater_manual_update_no_update_toast">Nenhuma atualização disponível</string>
-    <string name="bttv_updater_manual_update_update_toast">Atualização disponivel!</string>
+    <string name="bttv_updater_manual_update_update_toast">Atualização disponível!</string>
     <string name="bttv_updater_manual_update_error_toast">Ocorreu um erro</string>
     <string name="bttv_settings_open_highlights_dia_primary">Definir Palavras-Chave de Destaque</string>
     <string name="bttv_settings_open_highlights_dia_secondary">Abrir Dialogo de Palavras-Chave</string>

--- a/mod/app/src/test/java/bttv/mod/TokenizerTest.java
+++ b/mod/app/src/test/java/bttv/mod/TokenizerTest.java
@@ -21,8 +21,8 @@ import bttv.Res;
 import bttv.Tokenizer;
 import bttv.emote.Emote;
 import bttv.emote.Emotes;
-import tv.twitch.android.models.chat.AutoModMessageFlags;
 import tv.twitch.android.shared.chat.pub.model.messages.MessageToken;
+import tv.twitch.android.shared.chat.pub.model.messages.AutoModMessageFlags;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;

--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:7.4.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/mod/consumer/build.gradle
+++ b/mod/consumer/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
         applicationId "app.consumer"
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion 23
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -22,10 +22,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    namespace "app.consumer"
 }
 
 dependencies {
@@ -33,10 +30,10 @@ dependencies {
     // glide 4.10.0+
     implementation "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
     annotationProcessor "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation project(path: ':app')
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/mod/consumer/src/main/AndroidManifest.xml
+++ b/mod/consumer/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="app.consumer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -9,7 +8,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BTTV">
-        <activity android:name=".MainActivity">
+        <activity
+        android:name=".MainActivity"
+        android:exported="True">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/mod/consumer/src/main/res/values-night/themes.xml
+++ b/mod/consumer/src/main/res/values-night/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/mod/consumer/src/main/res/values/themes.xml
+++ b/mod/consumer/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/mod/gradle/wrapper/gradle-wrapper.properties
+++ b/mod/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mod/twitch/build.gradle
+++ b/mod/twitch/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion 23
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -22,24 +22,21 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    namespace "tv.twitch"
 }
 
 dependencies {
     def GLIDE_VERSION = "4.12.0"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    api 'com.google.dagger:dagger-android:2.35.1'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.35.1'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.35.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'com.google.android.material:material:1.9.0'
+    api 'com.google.dagger:dagger-android:2.51.1'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.51.1'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.51.1'
     api 'com.squareup.okhttp3:okhttp:4.0.1'
     api 'io.reactivex.rxjava2:rxandroid:2.1.1'
     api 'ru.noties:markwon:2.0.2'
     api "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/mod/twitch/src/main/AndroidManifest.xml
+++ b/mod/twitch/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tv.twitch">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/chat/pub/model/messages/MessageToken.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/chat/pub/model/messages/MessageToken.java
@@ -21,6 +21,14 @@ public abstract class MessageToken {
             this.id = id;
         }
 
+        public final String component1() {
+            return this.text;
+        }
+        public final String component2() {
+            return this.id;
+        }
+
+
     }
 
     public static final class TextToken extends MessageToken {


### PR DESCRIPTION
## Changes
<!-- What does this PR change? -->
Updates the dependencies, Gradle and build tools. Several linting warnings and errors are also fixed.
## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [ ] ~~I use the "bttv_" prefix for all resources I propose~~
 - [ ] ~~When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)~~
 - [ ] ~~If my change is significant enough, I added it to the CHANGELOG.md under `master`~~
 - [ ] ~~I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)~~
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).

I did not run ubi, because the build tools 33 use d8 instead of dx now but ubi itself seems to have dx hardcoded in some places. 