### PR TITLE
Fix Split chat not working on Livestreams

### DIFF
--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -72,6 +72,8 @@ public class SplitChat {
                 if (nestedChild.getId() == ResUtil.getResourceId(context, "chat_message_item", "id")) {
                     Log.d(TAG, "found chat_message_item: " + nestedChild.toString());
                     view = nestedChild;
+                    // Increase width of linearLayout to match parent to color the whole item
+                    linearLayout.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
                     break;
                 }
             }

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -60,16 +60,17 @@ public class SplitChat {
         View view = viewHolder.itemView;
         Context context = view.getContext();
 
-        // make sure we only change chat message items
-        // Other elements like redeems or Sub Anniversaries are ConstraintLayouts
-
-        // If view is a LinearLayout, check the childrens to find chat_message_item
+        // make sure we only change chat message items,
+        // which are LinearLayouts with chat_message_item children.
+        // Anything else is ignored.
+        int chatMessageItemResId = ResUtil.getResourceId(context, "chat_message_item", "id");
+        int chommentRootViewResId = ResUtil.getResourceId(context, "chomment_root_view", "id");
         if(view instanceof LinearLayout) {
             Log.d(TAG, "view is LinearLayout: " + view.toString());
             LinearLayout linearLayout = (LinearLayout) view;
             for (int j = 0; j < linearLayout.getChildCount(); j++) {
                 View nestedChild = linearLayout.getChildAt(j);
-                if (nestedChild.getId() == ResUtil.getResourceId(context, "chat_message_item", "id")) {
+                if (nestedChild.getId() == chatMessageItemResId) {
                     Log.d(TAG, "found chat_message_item: " + nestedChild.toString());
                     view = nestedChild;
                     // Increase width of linearLayout to match parent to color the whole item
@@ -78,11 +79,11 @@ public class SplitChat {
                 }
             }
         }
-        boolean hasChatMessageId = view.getId() == ResUtil.getResourceId(context, "chat_message_item", "id");
-        boolean hasChommentRootId = view.getId() == ResUtil.getResourceId(context, "chomment_root_view", "id");
+        boolean hasChatMessageId = view.getId() == chatMessageItemResId;
+        boolean hasChommentRootId = view.getId() == chommentRootViewResId;
 
         if (!(hasChatMessageId || hasChommentRootId)) {
-            Log.i(TAG, "view skipped, as it's not a chat message or chomment, " + viewHolder.toString() + " ID: " + view.getId() + " View: " + view.toString() + " Expected ID: " + ResUtil.getResourceId(context, "chat_message_item", "id") + " or " + ResUtil.getResourceId(context, "chomment_root_view", "id"));
+            Log.d(TAG, "view skipped, as it's not a chat message or chomment, " + viewHolder.toString() + " ID: " + view.getId() + " View: " + view.toString() + " Expected ID: " + chatMessageItemResId + " or " + chommentRootViewResId);
             reset(view);
             return;
         }

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -63,7 +63,7 @@ public class SplitChat {
         // make sure we only change chat message items,
         // which are LinearLayouts with chat_message_item children.
         // Anything else is ignored.
-        int chatMessageItemResId = ResUtil.getResourceId(context, "chat_message_item", "id"));
+        int chatMessageItemResId = ResUtil.getResourceId(context, "chat_message_item", "id");
         int chommentRootViewResId = ResUtil.getResourceId(context, "chomment_root_view", "id");
         if(view instanceof LinearLayout) {
             Log.d(TAG, "view is LinearLayout: " + view.toString());

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -63,6 +63,8 @@ public class SplitChat {
         // make sure we only change chat message items,
         // which are LinearLayouts with chat_message_item children.
         // Anything else is ignored.
+        int chatMessageItemResId = ResUtil.getResourceId(context, "chat_message_item", "id"));
+        int chommentRootViewResId = ResUtil.getResourceId(context, "chomment_root_view", "id");
         if(view instanceof LinearLayout) {
             Log.d(TAG, "view is LinearLayout: " + view.toString());
             LinearLayout linearLayout = (LinearLayout) view;

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -60,10 +60,9 @@ public class SplitChat {
         View view = viewHolder.itemView;
         Context context = view.getContext();
 
-        // make sure we only change chat message items
-        // Other elements like redeems or Sub Anniversaries are ConstraintLayouts
-
-        // If view is a LinearLayout, check the childrens to find chat_message_item
+        // make sure we only change chat message items,
+        // which are LinearLayouts with chat_message_item children.
+        // Anything else is ignored.
         if(view instanceof LinearLayout) {
             Log.d(TAG, "view is LinearLayout: " + view.toString());
             LinearLayout linearLayout = (LinearLayout) view;

--- a/mod/app/src/main/java/bttv/SplitChat.java
+++ b/mod/app/src/main/java/bttv/SplitChat.java
@@ -68,7 +68,7 @@ public class SplitChat {
             LinearLayout linearLayout = (LinearLayout) view;
             for (int j = 0; j < linearLayout.getChildCount(); j++) {
                 View nestedChild = linearLayout.getChildAt(j);
-                if (nestedChild.getId() == ResUtil.getResourceId(context, "chat_message_item", "id")) {
+                if (nestedChild.getId() == chatMessageItemResId) {
                     Log.d(TAG, "found chat_message_item: " + nestedChild.toString());
                     view = nestedChild;
                     // Increase width of linearLayout to match parent to color the whole item
@@ -77,11 +77,11 @@ public class SplitChat {
                 }
             }
         }
-        boolean hasChatMessageId = view.getId() == ResUtil.getResourceId(context, "chat_message_item", "id");
-        boolean hasChommentRootId = view.getId() == ResUtil.getResourceId(context, "chomment_root_view", "id");
+        boolean hasChatMessageId = view.getId() == chatMessageItemResId;
+        boolean hasChommentRootId = view.getId() == chommentRootViewResId;
 
         if (!(hasChatMessageId || hasChommentRootId)) {
-            Log.i(TAG, "view skipped, as it's not a chat message or chomment, " + viewHolder.toString() + " ID: " + view.getId() + " View: " + view.toString() + " Expected ID: " + ResUtil.getResourceId(context, "chat_message_item", "id") + " or " + ResUtil.getResourceId(context, "chomment_root_view", "id"));
+            Log.d(TAG, "view skipped, as it's not a chat message or chomment, " + viewHolder.toString() + " ID: " + view.getId() + " View: " + view.toString() + " Expected ID: " + chatMessageItemResId + " or " + chommentRootViewResId);
             reset(view);
             return;
         }

--- a/mod/twitch/src/main/java/tv/twitch/android/shared/chat/adapter/item/ChatMessageViewHolder.java
+++ b/mod/twitch/src/main/java/tv/twitch/android/shared/chat/adapter/item/ChatMessageViewHolder.java
@@ -1,0 +1,13 @@
+package tv.twitch.android.shared.chat.adapter.item;
+
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import tv.twitch.android.core.adapters.AbstractTwitchRecyclerViewHolder;
+
+public abstract class ChatMessageViewHolder extends AbstractTwitchRecyclerViewHolder {
+  public ChatMessageViewHolder(@NonNull View itemView) {
+    super(itemView);
+  }
+}

--- a/patches/tv.twitch.android.settings.cookieconsent.CookieConsentBottomSheetDialogPresenter.smali.patch
+++ b/patches/tv.twitch.android.settings.cookieconsent.CookieConsentBottomSheetDialogPresenter.smali.patch
@@ -1,0 +1,16 @@
+diff --git a/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali b/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
+index a757e1fb6..06cf1e9a0 100644
+--- a/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
++++ b/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
+@@ -283,6 +283,11 @@
+ 
+     invoke-static/range {p1 .. p6}, Ltv/twitch/android/core/mvp/rxutil/ISubscriptionHelper$DefaultImpls;->directSubscribe$default(Ltv/twitch/android/core/mvp/rxutil/ISubscriptionHelper;Lio/reactivex/Flowable;Ltv/twitch/android/core/mvp/rxutil/DisposeOn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+ 
++    # BTTV
++    # Set Consent for Cookie Consent Dialog to Disabled
++    invoke-direct {p0}, Ltv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter;->setConsentDisabled()V
++    # /BTTV
++
+     return-void
+ .end method
+ 


### PR DESCRIPTION
Fixes #673 <!-- If applicable -->

## Changes
Twitch changed chat messages in Live Streams to be LinearLayouts with the chat_message_item as a child. This fixes it to target the child rather than the LinearLayout to make Split Chat work again.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [ ] ~~I use the "bttv_" prefix for all resources I propose~~
 - [ ] ~~When adding a string I also added it to the `bttv.Res.strings` Enum and `res/values/strings.xml` (in `mod`) and `res/values/public.xml` (in `disass`)~~
 - [ ] ~~If my change is significant enough, I added it to the CHANGELOG.md under `master`~~
 - [ ] ~~I'll add myself and everyone else who contributed to this change to the contributors list using [all-contributors](https://allcontributors.org/docs/en/bot/usage)~~
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
