### PR TITLE
Fix settings not persisting

### DIFF
--- a/mod/app/src/main/java/bttv/settings/SettingsPresenter.java
+++ b/mod/app/src/main/java/bttv/settings/SettingsPresenter.java
@@ -75,10 +75,9 @@ public final class SettingsPresenter extends BaseSettingsPresenter {
 		MenuAdapterBinder binder = getAdapterBinder();
 		binder.getAdapter().removeAllSections();
 
-		MenuSection menuSection = new MenuSection(getSettingModels(), null, null, 0b110, null);
 		HeaderConfig headerCfg = new HeaderConfig(SectionHeaderDisplayConfig.IF_CONTENT,
 				"Fine tune your BTTV experience", null, 0, 0, null, null, false, null, null, 0b1111111100, null);
-		menuSection.updateHeaderConfig(headerCfg);
+		MenuSection menuSection = new MenuSection(getSettingModels(), null, headerCfg, 0b110, null);
 		binder.bindModels(getSettingModels(), getMSettingActionListener(), menuSection, null);
 	}
 
@@ -114,6 +113,10 @@ public final class SettingsPresenter extends BaseSettingsPresenter {
 		@Override
 		public void updatePreferenceBooleanState(ToggleMenuModel toggleMenuModel, boolean z) {
 			String key = toggleMenuModel.getEventName();
+			if(key == null) {
+				Log.w("LBTTVSettingsPC", "updatePreferenceBooleanState() key is null");
+				return;
+			}
 			Settings setting = Settings.get(key);
 
 			if (setting == null) {

--- a/mod/app/src/main/java/bttv/settings/abstractions/Switch.java
+++ b/mod/app/src/main/java/bttv/settings/abstractions/Switch.java
@@ -24,7 +24,7 @@ public class Switch {
                 SettingsPreferencesController.SettingsPreference.BTTVEmotesEnabled,
                 null,
                 null,
-                0b11011111110100,
+                0b1011110110100,
                 null
         );
     }

--- a/patches/tv.twitch.android.settings.cookieconsent.CookieConsentBottomSheetDialogPresenter.smali.patch
+++ b/patches/tv.twitch.android.settings.cookieconsent.CookieConsentBottomSheetDialogPresenter.smali.patch
@@ -1,0 +1,16 @@
+diff --git a/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali b/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
+index a757e1fb6..06cf1e9a0 100644
+--- a/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
++++ b/smali_classes6/tv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter.smali
+@@ -283,6 +283,11 @@
+ 
+     invoke-static/range {p1 .. p6}, Ltv/twitch/android/core/mvp/rxutil/ISubscriptionHelper$DefaultImpls;->directSubscribe$default(Ltv/twitch/android/core/mvp/rxutil/ISubscriptionHelper;Lio/reactivex/Flowable;Ltv/twitch/android/core/mvp/rxutil/DisposeOn;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+ 
++    # BTTV
++    # Set Consent for Cookie Consent Dialog to Disabled
++    invoke-direct {p0}, Ltv/twitch/android/settings/cookieconsent/CookieConsentBottomSheetDialogPresenter;->setConsentDisabled()V
++    # /BTTV
++
+     return-void
+ .end method
+ 


### PR DESCRIPTION
## Changes
<!-- What does this PR change? -->
Fixes the BTTV settings not persisting if changed. It was caused because of a changed number in Switch.java in one of the previous commits. This somehow causes the Event Name to be null for ToggleMenuModel's, which breaks persisting the changes. 
I changed the number back and also added an additional check for null values in SettingsPresenter (plus a slight change to the binding of the header to the MenuSection).

This fix might be worth a release ? Seeing as all the toggles in the BTTV settings menu are affected by this.

## Checklist
<!-- 
    Check the boxes like this:
    - [x] I tested my change

    Not applicable points should be strikethrough:
    - [ ] ~~I tested my change~~
 -->
 - [x] My change builds
 - [x] I tested my change
 - [x] I license my changes according to the [MIT License](https://github.com/bttv-android/bttv/blob/master/LICENSE).
